### PR TITLE
more flexible joystick configuration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ David Gow <david@davidgow.net>
 NY00123
 lemm
 BSzili
+KeyJ

--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -28,6 +28,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "ck_cross.h"
 #include "ck_play.h"
 
+#define US_MAX_JOYSTICK_NAME_LENGTH 28
+
+#define US_MAX_JOYSTICKS 2
+
 #define EXTRA_GRAPHICS_OPTIONS
 
 bool CK_US_ScoreBoxMenuProc(US_CardMsg msg, US_CardItem *item)
@@ -819,7 +823,7 @@ void CK_US_SetJoyBinding(US_CardItem *item, IN_JoyConfItem which_control)
 		}
 
 	        /* poll joysticks */
-		for (int i = 0; i < 2 /*IN_MAX_JOYSTICKS*/; i++)
+		for (int i = 0; i < US_MAX_JOYSTICKS; i++)
 		{
 			if (IN_JoyPresent(i))
 			{
@@ -852,7 +856,7 @@ void CK_US_SetJoyBinding(US_CardItem *item, IN_JoyConfItem which_control)
 	{
 		IN_PumpEvents();
 		button_mask = 0;
-		for (int i = 0; i < 2 /*IN_MAX_JOYSTICKS*/; i++)
+		for (int i = 0; i < US_MAX_JOYSTICKS; i++)
 		{
 			if (IN_JoyPresent(i))
 				button_mask |= IN_GetJoyButtonsDB(i);
@@ -1152,6 +1156,32 @@ bool CK_PaddleWar(US_CardMsg msg, US_CardItem *item)
 	return 1;
 }
 
+void CK_US_SetJoystickName(US_CardItem *item, int joystick)
+{
+	static char str[US_MAX_JOYSTICKS][US_MAX_JOYSTICK_NAME_LENGTH + 1];
+	char *pos = str[joystick];
+	const char* name = IN_GetJoyName(joystick);
+	if (name)
+	{
+		strcpy(pos, "USE ");
+		pos += 4;
+		if ((strlen(name) + 4) > US_MAX_JOYSTICK_NAME_LENGTH)
+		{
+			int n = US_MAX_JOYSTICK_NAME_LENGTH - 7;
+			memcpy(pos, name, n);
+			pos += n;
+			strcpy(pos, "...");
+		}
+		else
+		{
+			strcpy(pos, name);
+		}
+	}
+	else
+		sprintf(pos, "USE JOYSTICK #%d", joystick + 1);
+	item->caption = str[joystick];
+}
+
 void CK_US_UpdateOptionsMenus(void)
 {
 
@@ -1174,10 +1204,12 @@ void CK_US_UpdateOptionsMenus(void)
 		ck_us_configureMenuItems[4].state &= ~US_IS_Disabled;
 	else
 		ck_us_configureMenuItems[4].state |= US_IS_Disabled;
+	CK_US_SetJoystickName(&ck_us_configureMenuItems[4], 0);
 	if (IN_JoyPresent(1))
 		ck_us_configureMenuItems[5].state &= ~US_IS_Disabled;
 	else
 		ck_us_configureMenuItems[5].state |= US_IS_Disabled;
+	CK_US_SetJoystickName(&ck_us_configureMenuItems[5], 1);
 	if (IN_JoyPresent(0) || IN_JoyPresent(1))
 		ck_us_configureMenuItems[6].state &= ~US_IS_Disabled;
 	else

--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -116,6 +116,7 @@ bool CK_US_KeyboardMenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_US_Joystick1MenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_US_Joystick2MenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_US_GamepadMenuProc(US_CardMsg msg, US_CardItem *item);
+bool CK_US_JoyConfMenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_US_ConfigureMenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_PaddleWar(US_CardMsg msg, US_CardItem *item);
 
@@ -478,6 +479,16 @@ US_Card ck_us_joystick1Menu = {0, 0, &PIC_JOYSTICKCARD, 0, 0, &CK_US_Joystick1Me
 US_Card ck_us_joystick2Menu = {0, 0, &PIC_JOYSTICKCARD, 0, 0, &CK_US_Joystick2MenuProc, 0, 0, 0};
 US_Card ck_us_gamepadMenu = {0, 0, &PIC_JOYSTICKCARD, 0, 0, &CK_US_GamepadMenuProc, 0, 0, 0};
 
+// Joystick Config Menu
+US_CardItem ck_us_joyconfMenuItems[] = {
+	{US_ITEM_Normal, 0, IN_SC_J, "JUMP", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Normal, 0, IN_SC_P, "POGO", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Normal, 0, IN_SC_F, "FIRE", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Normal, 0, IN_SC_D, "DEAD ZONE", US_Comm_None, 0, 0, 0},
+	{US_ITEM_None, 0, IN_SC_None, 0, US_Comm_None, 0, 0, 0}};
+
+US_Card ck_us_joyconfMenu = {0, 0, &PIC_BUTTONSCARD, 0, ck_us_joyconfMenuItems, &CK_US_JoyConfMenuProc, 0, 0, 0};
+
 // Configure Menu
 US_CardItem ck_us_configureMenuItems[] = {
 	{US_ITEM_Submenu, 0, IN_SC_S, "SOUND", US_Comm_None, &ck_us_soundMenu, 0, 0},
@@ -487,6 +498,7 @@ US_CardItem ck_us_configureMenuItems[] = {
 	{US_ITEM_Submenu, 0, IN_SC_One, "USE JOYSTICK #1", US_Comm_None, &ck_us_joystick1Menu, 0, 0},
 	{US_ITEM_Submenu, 0, IN_SC_Two, "USE JOYSTICK #2", US_Comm_None, &ck_us_joystick2Menu, 0, 0},
 	//{ US_ITEM_Submenu, 0, IN_SC_G, "", US_Comm_None, &ck_us_gamepadMenu, 0, 0 },
+	{US_ITEM_Submenu, 0, IN_SC_J, "JOYSTICK CONFIGURATION", US_Comm_None, &ck_us_joyconfMenu, 0, 0},
 	{US_ITEM_None, 0, IN_SC_None, 0, US_Comm_None, 0, 0, 0}};
 
 US_Card ck_us_configureMenu = {0, 0, &PIC_CONFIGURECARD, 0, ck_us_configureMenuItems, &CK_US_ConfigureMenuProc, 0, 0, 0};
@@ -683,6 +695,174 @@ bool CK_US_Joystick2MenuProc(US_CardMsg msg, US_CardItem *item)
 bool CK_US_GamepadMenuProc(US_CardMsg msg, US_CardItem *item)
 {
 	return false;
+}
+
+bool CK_US_JoyConfMenuProc(US_CardMsg msg, US_CardItem *item)
+{
+	IN_JoyConfItem which_control;
+	int value;
+	char str[8], *spos;
+	int print_x, print_y;
+	static const int8_t deadzone_values[] = {
+		0, 5, 10, 15, 20, 25, 30, 35, 40, 50, 60, 70, 80, 90, -1
+	};
+
+	which_control = (IN_JoyConfItem) (item - ck_us_joyconfMenuItems);
+	value = IN_GetJoyConf(which_control);
+
+	switch (msg)
+	{
+	case US_MSG_DrawItem:
+
+		// Draw the item Icon and the key's name
+		VH_Bar(75, item->y, 159, 8, 8);
+		USL_DrawCardItemIcon(item);
+
+		US_SetPrintColour((item->state & US_IS_Selected) ? 2 : 10);
+		print_x = item->x + 8;
+		print_y = item->y + 1;
+		VH_DrawPropString(item->caption, print_x, print_y, 1, US_GetPrintColour());
+
+		// Draw the outer green bo
+		VH_Bar(item->x + 90, item->y, 40, 8, US_GetPrintColour() ^ 8);
+		VH_Bar(item->x + 91, item->y + 1, 38, 6, 8);
+
+		// construct the value string
+		spos = str;
+		if ((which_control != IN_joy_deadzone) && (value < 0))
+		{
+			*spos++ = 'N';
+			*spos++ = 'o';
+			*spos++ = 'n';
+			*spos++ = 'e';
+		}
+		else
+		{
+			if (which_control != IN_joy_deadzone)
+			{
+				*spos++ = 'B';
+				*spos++ = 't';
+				*spos++ = 'n';
+				*spos++ = ' ';
+			}
+			if (value >= 10)
+				*spos++ = '0' + (value / 10);
+			*spos++ = '0' + (value % 10);
+			if (which_control == IN_joy_deadzone)
+				*spos++ = '%';
+		}
+		*spos++ = '\0';
+
+		print_x = item->x + 96;
+		print_y = item->y + 1;
+		VH_DrawPropString(str, print_x, print_y, 1, US_GetPrintColour());
+		return true;
+
+	case US_MSG_ItemEntered:
+		if (which_control == IN_joy_deadzone)
+		{
+			int i;
+			for (i = 0;  (deadzone_values[i] >= 0) && (deadzone_values[i] <= value);  i++);
+			value = deadzone_values[(deadzone_values[i] < 0) ? 0 : i];
+			IN_SetJoyConf(which_control, value);
+		}
+		else
+			CK_US_SetJoyBinding(item, which_control);
+
+		US_DrawCards();
+		return true;
+	}
+
+	return false;
+}
+
+void CK_US_SetJoyBinding(US_CardItem *item, IN_JoyConfItem which_control)
+{
+	bool cursor = false;
+	bool unassign = false;
+	uint32_t lasttime = 0;
+	uint16_t button_mask = 0;
+	IN_ScanCode last_scan = IN_SC_None;
+
+	US_SetPrintColour(2);
+	IN_ClearKeysDown();
+
+	/* Prompt the user to press a button */
+	while (1)
+	{
+		IN_PumpEvents();
+		
+		/* Flicker the cursor */
+		if (SD_GetTimeCount() >= lasttime)
+		{
+			/* time_count */
+			cursor = !cursor;
+
+			/* Draw the rectangle */
+			VH_Bar(item->x + 90, item->y, 40, 8, US_GetPrintColour() ^ 8);
+			VH_Bar(item->x + 91, item->y + 1, 38, 6, 8);
+
+			/* Draw the cursor */
+			if (cursor)
+				VH_DrawTile8(item->x + 106, item->y, 100);
+
+			//VW_UpdateScreen();
+			lasttime = SD_GetTimeCount() + 35; /* time_count */
+			VL_Present();
+		}
+
+		/* any key cancels the selection */
+		last_scan = IN_GetLastScan();
+		if (last_scan != 0)
+		{
+			break;
+		}
+
+	        /* poll joysticks */
+		for (int i = 0; i < 2 /*IN_MAX_JOYSTICKS*/; i++)
+		{
+			if (IN_JoyPresent(i))
+			{
+				button_mask = IN_GetJoyButtonsDB(i);
+				if (button_mask)
+					break;
+			}
+		}
+		if (button_mask != 0)
+			break;
+		VL_Present();
+	}
+
+	/* assign the joystick button */
+	if (last_scan == IN_SC_Backspace)
+		IN_SetJoyConf(which_control, -1);  /* Backspace = unassign */
+	else if (button_mask)
+	{
+		int bit = 0;
+		while ((button_mask & 1) == 0)
+		{
+			bit++;
+			button_mask >>= 1;
+		}
+		IN_SetJoyConf(which_control, bit);
+	}
+
+	/* wait until all joystick buttons have been released */
+	while (1)
+	{
+		IN_PumpEvents();
+		button_mask = 0;
+		for (int i = 0; i < 2 /*IN_MAX_JOYSTICKS*/; i++)
+		{
+			if (IN_JoyPresent(i))
+				button_mask |= IN_GetJoyButtonsDB(i);
+		}
+		if (button_mask == 0)
+			break;
+		VL_Present();
+	}
+
+	IN_ClearKeysDown();
 }
 
 bool CK_US_ConfigureMenuProc(US_CardMsg msg, US_CardItem *item)
@@ -998,6 +1178,10 @@ void CK_US_UpdateOptionsMenus(void)
 		ck_us_configureMenuItems[5].state &= ~US_IS_Disabled;
 	else
 		ck_us_configureMenuItems[5].state |= US_IS_Disabled;
+	if (IN_JoyPresent(0) || IN_JoyPresent(1))
+		ck_us_configureMenuItems[6].state &= ~US_IS_Disabled;
+	else
+		ck_us_configureMenuItems[6].state |= US_IS_Disabled;
 
 		/* Set up the gamepad menu item */
 #if 0

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -715,3 +715,8 @@ bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn)
 	return (btn_id < 0) ? 0 : ((mask >> btn_id) & 1);
 }
 
+const char* IN_GetJoyName(int joystick)
+{
+	return (in_backend->joyPresent(joystick) && in_backend->joyGetName)
+	     ? in_backend->joyGetName(joystick) : NULL;
+}

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -119,6 +119,10 @@ IN_Backend *in_backend = 0;
 
 IN_KeyMapping in_kbdControls;
 
+/* In Omnispeak, which doesn't support the classic Gravis Gamepad anyway,
+ * we misuse in_gamepadButtons for storing the joystick configuration
+ * (three buttons and dead zone); this way we get persistence "for free",
+ * as the old gamepadButtons configuration is stored in the CONFIG.CK? files */
 int16_t in_gamepadButtons[4];
 
 IN_ScanCode *key_controls[] = {
@@ -480,8 +484,10 @@ void IN_ReadCursor(IN_Cursor *cursor)
 			cursor->yMotion = IN_motion_Down;
 
 		uint16_t buttons = IN_GetJoyButtonsDB(joy);
-		cursor->button0 = buttons & 1;
-		cursor->button1 = buttons & 2;
+		/* TODO: maybe ignore button mappings in the menu and
+		 *       map _all_ buttons to button0? */
+		cursor->button0 = IN_GetJoyButtonFromMask(buttons, IN_joy_jump);
+		cursor->button1 = IN_GetJoyButtonFromMask(buttons, IN_joy_fire);
 	}
 }
 
@@ -573,8 +579,9 @@ void IN_ReadControls(int player, IN_ControlFrame *controls)
 				controls->yDirection = IN_motion_Down;
 
 			uint16_t buttons = IN_GetJoyButtonsDB(joy);
-			controls->jump = buttons & 1;
-			controls->pogo = buttons & 2;
+			controls->jump = IN_GetJoyButtonFromMask(buttons, IN_joy_jump);
+			controls->pogo = IN_GetJoyButtonFromMask(buttons, IN_joy_pogo);
+			controls->button2 = IN_GetJoyButtonFromMask(buttons, IN_joy_fire);
 		}
 
 		controls->dir = in_dirTable[3 * (controls->yDirection + 1) + controls->xDirection + 1];
@@ -687,3 +694,24 @@ bool IN_UserInput(int tics, bool waitPress)
 
 	return false;
 }
+
+int IN_GetJoyConf(IN_JoyConfItem item)
+{
+	return ((item >= IN_joy_min_) && (item <= IN_joy_max_))
+		? in_gamepadButtons[(int) item] : 0;
+}
+
+void IN_SetJoyConf(IN_JoyConfItem item, int value)
+{
+	if ((item >= IN_joy_min_) && (item <= IN_joy_max_))
+		in_gamepadButtons[(int) item] = (int16_t) value;
+	if ((item == IN_joy_deadzone) && (in_backend->joySetDeadzone))
+		in_backend->joySetDeadzone(value);
+}
+
+bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn)
+{
+	int btn_id = in_gamepadButtons[(int) btn];
+	return (btn_id < 0) ? 0 : ((mask >> btn_id) & 1);
+}
+

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -284,6 +284,7 @@ bool IN_UserInput(int tics, bool arg4);
 int IN_GetJoyConf(IN_JoyConfItem item);
 void IN_SetJoyConf(IN_JoyConfItem item, int value);
 bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn);
+const char* IN_GetJoyName(int joystick);
 
 // Called by the backend.
 bool INL_StartJoy(int joystick);
@@ -303,6 +304,7 @@ typedef struct IN_Backend
 	void (*joyGetAbs)(int joystick, int *x, int *y);
 	uint16_t (*joyGetButtons)(int joystick);
 	void (*joySetDeadzone)(int percent);
+	const char* (*joyGetName)(int joystick);
 } IN_Backend;
 
 IN_Backend *IN_Impl_GetBackend();

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -242,6 +242,16 @@ extern IN_ControlType in_controlType;
 extern bool in_Paused;
 extern bool in_disableJoysticks;
 
+typedef enum IN_JoyConfItem
+{
+	IN_joy_jump     = 0,
+	IN_joy_pogo     = 1,
+	IN_joy_fire     = 2,
+	IN_joy_deadzone = 3,
+	IN_joy_min_ = IN_joy_jump,
+	IN_joy_max_ = IN_joy_deadzone
+} IN_JoyConfItem;
+
 void IN_PumpEvents();
 void IN_WaitKey();
 const char *IN_GetScanName(IN_ScanCode scan);
@@ -271,6 +281,9 @@ void IN_ReadControls(int player, IN_ControlFrame *controls);
 void IN_WaitButton();
 int IN_CheckAck();
 bool IN_UserInput(int tics, bool arg4);
+int IN_GetJoyConf(IN_JoyConfItem item);
+void IN_SetJoyConf(IN_JoyConfItem item, int value);
+bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn);
 
 // Called by the backend.
 bool INL_StartJoy(int joystick);
@@ -289,6 +302,7 @@ typedef struct IN_Backend
 	bool (*joyPresent)(int joystick);
 	void (*joyGetAbs)(int joystick, int *x, int *y);
 	uint16_t (*joyGetButtons)(int joystick);
+	void (*joySetDeadzone)(int percent);
 } IN_Backend;
 
 IN_Backend *IN_Impl_GetBackend();

--- a/src/id_in_null.c
+++ b/src/id_in_null.c
@@ -63,6 +63,15 @@ uint16_t IN_NULL_JoyGetButtons(int joystick)
 	return (button0) | (button1 << 1);
 }
 
+void IN_NULL_JoySetDeadzone(int percent)
+{
+}
+
+const char* IN_NULL_JoyGetName(int joystick)
+{
+	return NULL;
+}
+
 IN_Backend in_null_backend = {
 	.startup = IN_NULL_Startup,
 	.shutdown = 0,
@@ -73,6 +82,8 @@ IN_Backend in_null_backend = {
 	.joyPresent = IN_NULL_JoyPresent,
 	.joyGetAbs = IN_NULL_JoyGetAbs,
 	.joyGetButtons = IN_NULL_JoyGetButtons,
+	.joySetDeadzone = IN_NULL_JoySetDeadzone,
+	.joyGetName = IN_NULL_JoyGetName,
 };
 
 IN_Backend *IN_Impl_GetBackend()

--- a/src/id_in_sdl.c
+++ b/src/id_in_sdl.c
@@ -443,14 +443,19 @@ uint16_t IN_SDL_JoyGetButtons(int joystick)
 	return mask;
 }
 
-void IN_SDL_JoySetDeadzone(int percent) {
+void IN_SDL_JoySetDeadzone(int percent)
+{
 	if ((percent >= 0) && (percent <= 100))
 		in_joystickDeadzone = (32768 * percent + 50) / 100;
 }
 
 const char* IN_SDL_JoyGetName(int joystick)
 {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	return SDL_JoystickName(in_joysticks[joystick]);
+#else
+	return SDL_JoystickName(joystick);
+#endif
 }
 
 IN_Backend in_sdl_backend = {

--- a/src/id_in_sdl.c
+++ b/src/id_in_sdl.c
@@ -448,6 +448,11 @@ void IN_SDL_JoySetDeadzone(int percent) {
 		in_joystickDeadzone = (32768 * percent + 50) / 100;
 }
 
+const char* IN_SDL_JoyGetName(int joystick)
+{
+	return SDL_JoystickName(in_joysticks[joystick]);
+}
+
 IN_Backend in_sdl_backend = {
 	.startup = IN_SDL_Startup,
 	.shutdown = 0,
@@ -459,6 +464,7 @@ IN_Backend in_sdl_backend = {
 	.joyGetAbs = IN_SDL_JoyGetAbs,
 	.joyGetButtons = IN_SDL_JoyGetButtons,
 	.joySetDeadzone = IN_SDL_JoySetDeadzone,
+	.joyGetName = IN_SDL_JoyGetName,
 };
 
 IN_Backend *IN_Impl_GetBackend()

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -716,6 +716,10 @@ void US_LoadConfig(void)
 		ck_scoreBoxEnabled = true;
 		ck_twoButtonFiring = false;
 		configFileLoaded = false;
+		in_gamepadButtons[0] = 0;
+		in_gamepadButtons[1] = 1;
+		in_gamepadButtons[2] = -1;
+		in_gamepadButtons[3] = 30;
 		//ck_highScoresDirty = 1; // Unused?
 	}
 	SD_Default(configFileLoaded && (hadAdlib == AdLibPresent), sd, sm);

--- a/src/id_us_2.c
+++ b/src/id_us_2.c
@@ -45,6 +45,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 void USL_DrawCardItemIcon(US_CardItem *item);
 void CK_US_SetKeyBinding(US_CardItem *item, int which_control);
+void CK_US_SetJoyBinding(US_CardItem *item, IN_JoyConfItem which_control);
 #include "ck_us_2.c"
 
 // Card stack can have at most 7 cards

--- a/src/id_vl_sdl12.c
+++ b/src/id_vl_sdl12.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "id_vl.h"
 #include "id_vl_private.h"
+#include "ck_cross.h"
 
 static SDL_Surface *vl_sdl12_screenSurface;
 static SDL_Rect vl_sdl12_screenBorderedRect;


### PR DESCRIPTION
- added option menu to configure joystick button mappings for jump, pogo, and fire, and the dead zone
- settings are saved into CONFIG.CKx by misusing the otherwise unused Gravis Gamepad settings variable (`in_gamepadButtons`)
- settings menu now shows the names of the joysticks (if available) instead of just a number