### PR TITLE
slightly improved joystick motion

### DIFF
--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -115,6 +115,17 @@ bool CK_US_BorderMenuProc(US_CardMsg msg, US_CardItem *item)
 
 #endif
 
+bool CK_US_JoyMotionModeMenuProc(US_CardMsg msg, US_CardItem *item)
+{
+	if (msg != US_MSG_CardEntered)
+		return false;
+
+	in_joyAdvancedMotion = !in_joyAdvancedMotion;
+	USL_CtlDialog((in_joyAdvancedMotion ? "Motion mode set to modern" : "Motion mode set to classic"), "Press any key", NULL);
+	CK_US_UpdateOptionsMenus();
+	return true;
+}
+
 bool CK_US_ControlsMenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_US_KeyboardMenuProc(US_CardMsg msg, US_CardItem *item);
 bool CK_US_Joystick1MenuProc(US_CardMsg msg, US_CardItem *item);
@@ -430,6 +441,7 @@ US_Card ck_us_fullscreenMenu = {0, 0, 0, 0, 0, &CK_US_FullscreenMenuProc, 0, 0, 
 US_Card ck_us_aspectCorrectMenu = {0, 0, 0, 0, 0, &CK_US_AspectCorrectMenuProc, 0, 0, 0};
 US_Card ck_us_borderMenu = {0, 0, 0, 0, 0, &CK_US_BorderMenuProc, 0, 0, 0};
 #endif
+US_Card ck_us_joyMotionModeMenu = {0, 0, 0, 0, 0, &CK_US_JoyMotionModeMenuProc, 0, 0, 0};
 
 // Options menu
 US_CardItem ck_us_optionsMenuItems[] = {
@@ -489,6 +501,7 @@ US_CardItem ck_us_joyconfMenuItems[] = {
 	{US_ITEM_Normal, 0, IN_SC_P, "POGO", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_F, "FIRE", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_D, "DEAD ZONE", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Submenu, 0, IN_SC_M, "", US_Comm_None, &ck_us_joyMotionModeMenu, 0, 0},
 	{US_ITEM_None, 0, IN_SC_None, 0, US_Comm_None, 0, 0, 0}};
 
 US_Card ck_us_joyconfMenu = {0, 0, &PIC_BUTTONSCARD, 0, ck_us_joyconfMenuItems, &CK_US_JoyConfMenuProc, 0, 0, 0};
@@ -710,6 +723,9 @@ bool CK_US_JoyConfMenuProc(US_CardMsg msg, US_CardItem *item)
 	static const int8_t deadzone_values[] = {
 		0, 5, 10, 15, 20, 25, 30, 35, 40, 50, 60, 70, 80, 90, -1
 	};
+
+	if (item == &ck_us_joyconfMenuItems[4])
+		return false;  // no special handling for the motion mode option
 
 	which_control = (IN_JoyConfItem) (item - ck_us_joyconfMenuItems);
 	value = IN_GetJoyConf(which_control);
@@ -1194,6 +1210,7 @@ void CK_US_UpdateOptionsMenus(void)
 	ck_us_optionsMenuItems[5].caption = vl_isAspectCorrected ? "CORRECT ASPECT RATIO (ON)" : "CORRECT ASPECT RATIO (OFF)";
 	ck_us_optionsMenuItems[6].caption = vl_hasOverscanBorder ? "OVERSCAN BORDER (ON)" : "OVERSCAN BORDER (OFF)";
 #endif
+	ck_us_joyconfMenuItems[4].caption = in_joyAdvancedMotion ? "MOTION MODE (MODERN)" : "MOTION MODE (CLASSIC)";
 
 	// Disable Two button firing selection if required
 	ck_us_buttonsMenuItems[2].state &= ~US_IS_Disabled;

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -241,6 +241,7 @@ extern IN_ControlType in_controlType;
 
 extern bool in_Paused;
 extern bool in_disableJoysticks;
+extern bool in_joyAdvancedMotion;
 
 typedef enum IN_JoyConfItem
 {
@@ -303,8 +304,11 @@ typedef struct IN_Backend
 	bool (*joyPresent)(int joystick);
 	void (*joyGetAbs)(int joystick, int *x, int *y);
 	uint16_t (*joyGetButtons)(int joystick);
-	void (*joySetDeadzone)(int percent);
 	const char* (*joyGetName)(int joystick);
+
+	// minimum and maximum values returned by joyGetAbs();
+	// requirement: 0 < (joyAxisMax - joyAxisMin) <= 92681
+	int joyAxisMin, joyAxisMax;
 } IN_Backend;
 
 IN_Backend *IN_Impl_GetBackend();

--- a/src/id_in_dos.c
+++ b/src/id_in_dos.c
@@ -128,6 +128,8 @@ IN_Backend in_dos_backend = {
 	.joyPresent = IN_DOS_JoyPresent,
 	.joyGetAbs = IN_DOS_JoyGetAbs,
 	.joyGetButtons = IN_DOS_JoyGetButtons,
+	.joyAxisMin = -1000,
+	.joyAxisMax =  1000,
 };
 
 IN_Backend *IN_Impl_GetBackend()

--- a/src/id_in_null.c
+++ b/src/id_in_null.c
@@ -63,10 +63,6 @@ uint16_t IN_NULL_JoyGetButtons(int joystick)
 	return (button0) | (button1 << 1);
 }
 
-void IN_NULL_JoySetDeadzone(int percent)
-{
-}
-
 const char* IN_NULL_JoyGetName(int joystick)
 {
 	return NULL;
@@ -82,8 +78,9 @@ IN_Backend in_null_backend = {
 	.joyPresent = IN_NULL_JoyPresent,
 	.joyGetAbs = IN_NULL_JoyGetAbs,
 	.joyGetButtons = IN_NULL_JoyGetButtons,
-	.joySetDeadzone = IN_NULL_JoySetDeadzone,
 	.joyGetName = IN_NULL_JoyGetName,
+	.joyAxisMin = -1000,
+	.joyAxisMax =  1000,
 };
 
 IN_Backend *IN_Impl_GetBackend()

--- a/src/id_in_sdl.c
+++ b/src/id_in_sdl.c
@@ -29,7 +29,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 SDL_Joystick *in_joysticks[IN_MAX_JOYSTICKS];
 bool in_joystickPresent[IN_MAX_JOYSTICKS];
-static int in_joystickDeadzone = 8689;
+static int in_joystickDeadzone = 8689 * 8689;
+
+// the "diagonal slope" selects the sensitivity of the joystick
+// regarding diagonal directions
+//#define IN_JOYSTICK_DIAGONAL_SLOPE   0,1    // only diagonals (not a good idea!)
+  #define IN_JOYSTICK_DIAGONAL_SLOPE   1,3    // slight preference for diagonals
+//#define IN_JOYSTICK_DIAGONAL_SLOPE  29,70   // diagonals have same sensitivity as main directions
+//#define IN_JOYSTICK_DIAGONAL_SLOPE   1,2    // slight preference for main directions
+//#define IN_JOYSTICK_DIAGONAL_SLOPE   1,1    // no diagonals at all (not a good idea!)
+static const int32_t in_joystickDiagonalSlope[2] = { IN_JOYSTICK_DIAGONAL_SLOPE };
 
 // SDLKey -> IN_SC
 #define INL_MapKey(sdl, in_sc) \
@@ -417,17 +426,48 @@ bool IN_SDL_JoyPresent(int joystick)
 	return in_joystickPresent[joystick];
 }
 
-static int IN_ApplyDeadZone(int value)
-{
-	return (abs(value) <= in_joystickDeadzone) ? 0 : value;
-}
-
 void IN_SDL_JoyGetAbs(int joystick, int *x, int *y)
 {
+	int32_t valX, valY, resX, resY, signX, signY;
+
+	// "Quantize" the raw joystick position into one of the nine discrete
+	// positions we need in the game (center / neutral, four main directions,
+	// four diagonals). For the center, a circular "deadzone" is applied.
+	// The remaining coordinates are split into eight radial segments,
+	// whereby the size of the segments for the main directions versus the
+	// diagonals can be tuned using the slope parameters at the beginning
+	// of this file. (This could easily be turned into an option later on.)
+
+	// get raw data from joystick
+	valX = SDL_JoystickGetAxis(in_joysticks[joystick], 0);
+	valY = SDL_JoystickGetAxis(in_joysticks[joystick], 1);
+
+	// extract the quadrant and map values into the upper-right quadrant
+	signX = valX >> 31;
+	signY = valY >> 31;
+	valX = abs(valX);
+	valY = abs(valY);
+
+	// check against the deadzone first
+	if ((valX * valX + valY * valY) < in_joystickDeadzone)
+	{
+		resX = resY = 0;
+	}
+	else
+	{
+		// not in deadzone -> classify into main horizontal,
+		// main vertical or diagonal directions
+		resX = (valY * in_joystickDiagonalSlope[0] > valX * in_joystickDiagonalSlope[1]) ? 0 : 32767;
+		resY = (valX * in_joystickDiagonalSlope[0] > valY * in_joystickDiagonalSlope[1]) ? 0 : 32767;
+		if (resX && resY)
+			resX = resY = 23169;  // keep diagonal coordinates on unit circle
+	}
+
+	// flip the result back into the proper quadrant
 	if (x)
-		*x = IN_ApplyDeadZone(SDL_JoystickGetAxis(in_joysticks[joystick], 0));
+		*x = (resX ^ signX) - signX;
 	if (y)
-		*y = IN_ApplyDeadZone(SDL_JoystickGetAxis(in_joysticks[joystick], 1));
+		*y = (resY ^ signY) - signY;
 }
 
 uint16_t IN_SDL_JoyGetButtons(int joystick)
@@ -446,7 +486,10 @@ uint16_t IN_SDL_JoyGetButtons(int joystick)
 void IN_SDL_JoySetDeadzone(int percent)
 {
 	if ((percent >= 0) && (percent <= 100))
+	{
 		in_joystickDeadzone = (32768 * percent + 50) / 100;
+		in_joystickDeadzone *= in_joystickDeadzone;
+	}
 }
 
 const char* IN_SDL_JoyGetName(int joystick)


### PR DESCRIPTION
This improves the "quantization" of the analog joystick input into digital 8-directional movements a bit.

Here's a visualization of how the old code mapped the X/Y coordinates from the joystick into the discrete inputs to the game (different colors):
![omnispeak_joystick_old](https://user-images.githubusercontent.com/18756274/61981646-8768fc00-affa-11e9-9440-11f225bc3b78.png)

And that's how it looks now:
![omnispeak_joystick_new](https://user-images.githubusercontent.com/18756274/61981660-8f28a080-affa-11e9-9086-78c412744ff6.png)

The main effect here is that the diagonal directions are easier to reach, especially with larger deadzones. The new code also makes it easier to fine-tune *how* sensitive the diagonals shall be; currently, it's a compile-time constant, but it would be easy to make this user-configurable once we have a way to save the setting.