### PR TITLE
Fix failed compilation on non-x86 Linux platform

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -286,11 +286,6 @@ OBJ += $(CKOBJECTS:%=$(OBJDIR)/%)
 OBJ += $(OPLOBJECTS:%=$(OBJDIR)/%)
 DEPS := $(OBJ:%.o=%.d)
 
-UNAME_P := $(shell uname -p)
-ifneq ($(filter %86,$(UNAME_P)),)
-	ARCH_FLAGS := -mno-ms-bitfields
-endif
-
 
 all: $(OUTBIN) binfiles batfiles
 
@@ -330,7 +325,7 @@ $(BINDIR):
 
 $(OBJDIR)/%.o: %.c $(SDL_DIR)
 	@mkdir -p $(dir $@)
-	$(CXX) $(SYSFLAGS) $(CXXFLAGS) $(SDL_CFLAGS) $(ARCH_FLAGS) -c -MMD -o $@ $<
+	$(CXX) $(SYSFLAGS) $(CXXFLAGS) $(SDL_CFLAGS) -c -MMD -o $@ $<
 
 $(OBJDIR)/windowsres.res: windowsres.rc
 	mkdir -p $(dir $@)

--- a/src/Makefile
+++ b/src/Makefile
@@ -286,7 +286,6 @@ OBJ += $(CKOBJECTS:%=$(OBJDIR)/%)
 OBJ += $(OPLOBJECTS:%=$(OBJDIR)/%)
 DEPS := $(OBJ:%.o=%.d)
 
-
 all: $(OUTBIN) binfiles batfiles
 
 help:

--- a/src/Makefile
+++ b/src/Makefile
@@ -286,6 +286,12 @@ OBJ += $(CKOBJECTS:%=$(OBJDIR)/%)
 OBJ += $(OPLOBJECTS:%=$(OBJDIR)/%)
 DEPS := $(OBJ:%.o=%.d)
 
+UNAME_P := $(shell uname -p)
+ifneq ($(filter %86,$(UNAME_P)),)
+	ARCH_FLAGS := -mno-ms-bitfields
+endif
+
+
 all: $(OUTBIN) binfiles batfiles
 
 help:
@@ -324,7 +330,7 @@ $(BINDIR):
 
 $(OBJDIR)/%.o: %.c $(SDL_DIR)
 	@mkdir -p $(dir $@)
-	$(CXX) $(SYSFLAGS) $(CXXFLAGS) $(SDL_CFLAGS) -mno-ms-bitfields -c -MMD -o $@ $<
+	$(CXX) $(SYSFLAGS) $(CXXFLAGS) $(SDL_CFLAGS) $(ARCH_FLAGS) -c -MMD -o $@ $<
 
 $(OBJDIR)/windowsres.res: windowsres.rc
 	mkdir -p $(dir $@)


### PR DESCRIPTION
The program fails to compile on ppc64le because the `-mno-ms-bitfields` flag is only available for x86 processor.

This commit resolves that issue by adding a condition check for x86 processor for that flag.