### PR TITLE
make the game (almost) fully controllable with a gamepad

### DIFF
--- a/src/ck_inter.c
+++ b/src/ck_inter.c
@@ -324,6 +324,9 @@ void AnimateTerminator(void)
 	int cmdrLeftEdgeFromScreenLeft;
 	int delaytime;
 
+	bool joyButtonPressedNow = false;
+	bool joyButtonPressedPrev = false;
+
 	// At the end of the terminator scrolling, left edge of the commander graphic is
 	// this many pixels from the Left/Right edge of the Visible screen
 	// (i.e., a negative value means an offset to the left)
@@ -467,6 +470,11 @@ void AnimateTerminator(void)
 
 		// Stop drawing if key pressed
 		if (IN_CheckAck() /*IN_IsUserInput()*/ && IN_GetLastScan() == IN_SC_F1)
+			IN_SetLastScan(IN_SC_Space);
+
+		joyButtonPressedPrev = joyButtonPressedNow;
+		joyButtonPressedNow = (IN_JoyPresent(0) && IN_GetJoyButtonsDB(0)) || (IN_JoyPresent(1) && IN_GetJoyButtonsDB(1));
+		if (joyButtonPressedPrev && !joyButtonPressedNow)
 			IN_SetLastScan(IN_SC_Space);
 
 		if (IN_GetLastScan())

--- a/src/ck_play.c
+++ b/src/ck_play.c
@@ -98,6 +98,9 @@ bool ck_gamePadEnabled;
 // Pogo timer for two-button firing
 int ck_pogoTimer;
 
+// current frame's input state
+IN_ControlFrame ck_inputFrame;
+
 // A bunch of global variables from other modules that should be
 // handled better, but are just defined here for now
 
@@ -1135,10 +1138,15 @@ void CK_CheckKeys()
 #endif
 
 		// Go back to wristwatch
-		if ((IN_GetLastScan() >= IN_SC_F2 && IN_GetLastScan() <= IN_SC_F7) || IN_GetLastScan() == IN_SC_Escape)
+		if ((IN_GetLastScan() >= IN_SC_F2 && IN_GetLastScan() <= IN_SC_F7)
+		    || IN_GetLastScan() == IN_SC_Escape
+		    || ck_inputFrame.button3)
 		{
-
 			// clang-format on
+
+			// don't re-enter menu immediately
+			ck_inputFrame.button3 = false;
+
 			// VW_SyncPages();
 			StopMusic();
 			US_RunCards();
@@ -1204,8 +1212,6 @@ void CK_CheckKeys()
 		Quit(NULL);
 	}
 }
-
-IN_ControlFrame ck_inputFrame;
 
 void CK_HandleInput()
 {

--- a/src/ck_play.c
+++ b/src/ck_play.c
@@ -1140,11 +1140,15 @@ void CK_CheckKeys()
 		// Go back to wristwatch
 		if ((IN_GetLastScan() >= IN_SC_F2 && IN_GetLastScan() <= IN_SC_F7)
 		    || IN_GetLastScan() == IN_SC_Escape
-		    || ck_inputFrame.button3)
+#ifndef CK_VANILLA
+		    || ck_inputFrame.button3
+#endif
+		)
 		{
 			// clang-format on
 
-			// don't re-enter menu immediately
+			// don't re-enter menu immediately if we came here
+			// via joystick button
 			ck_inputFrame.button3 = false;
 
 			// VW_SyncPages();

--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -560,8 +560,9 @@ US_CardItem ck_us_joyconfMenuItems[] = {
 	{US_ITEM_Normal, 0, IN_SC_J, "JUMP", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_P, "POGO", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_F, "FIRE", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Normal, 0, IN_SC_M, "MENU", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_D, "DEAD ZONE", US_Comm_None, 0, 0, 0},
-	{US_ITEM_Submenu, 0, IN_SC_M, "", US_Comm_None, &ck_us_joyMotionModeMenu, 0, 0},
+	{US_ITEM_Submenu, 0, IN_SC_J, "", US_Comm_None, &ck_us_joyMotionModeMenu, 0, 0},
 	{US_ITEM_None, 0, IN_SC_None, 0, US_Comm_None, 0, 0, 0}};
 
 US_Card ck_us_joyconfMenu = {0, 0, &PIC_BUTTONSCARD, 0, ck_us_joyconfMenuItems, &CK_US_JoyConfMenuProc, 0, 0, 0};
@@ -789,7 +790,7 @@ bool CK_US_JoyConfMenuProc(US_CardMsg msg, US_CardItem *item)
 	static const int8_t deadzone_values[] = {
 		0, 5, 10, 15, 20, 25, 30, 35, 40, 50, 60, 70, 80, 90, -1};
 
-	if (item == &ck_us_joyconfMenuItems[4])
+	if (item == &ck_us_joyconfMenuItems[(int)IN_joy_modern])
 		return false; // no special handling for the motion mode option
 
 	which_control = (IN_JoyConfItem)(item - ck_us_joyconfMenuItems);
@@ -1282,7 +1283,7 @@ void CK_US_UpdateOptionsMenus(void)
 	ck_us_optionsMenuItems[6].caption = vl_hasOverscanBorder ? "OVERSCAN BORDER (ON)" : "OVERSCAN BORDER (OFF)";
 #endif
 #ifdef EXTRA_JOYSTICK_OPTIONS
-	ck_us_joyconfMenuItems[4].caption = in_joyAdvancedMotion ? "MOTION MODE (MODERN)" : "MOTION MODE (CLASSIC)";
+	ck_us_joyconfMenuItems[(int)IN_joy_modern].caption = in_joyAdvancedMotion ? "MOTION MODE (MODERN)" : "MOTION MODE (CLASSIC)";
 #endif
 
 	// Disable Two button firing selection if required

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -596,7 +596,7 @@ void IN_ReadCursor(IN_Cursor *cursor)
 		/* TODO: maybe ignore button mappings in the menu and
 		 *       map _all_ buttons to button0? */
 		cursor->button0 = IN_GetJoyButtonFromMask(buttons, IN_joy_jump);
-		cursor->button1 = IN_GetJoyButtonFromMask(buttons, IN_joy_fire);
+		cursor->button1 = IN_GetJoyButtonFromMask(buttons, IN_joy_pogo);
 	}
 }
 

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -121,10 +121,10 @@ IN_Backend *in_backend = 0;
 
 IN_KeyMapping in_kbdControls;
 
-/* In Omnispeak, which doesn't support the classic Gravis Gamepad anyway,
- * we misuse in_gamepadButtons for storing the joystick configuration
- * (three buttons and dead zone); this way we get persistence "for free",
- * as the old gamepadButtons configuration is stored in the CONFIG.CK? files */
+// In Omnispeak, which doesn't support the classic Gravis Gamepad anyway,
+// we misuse in_gamepadButtons to store more buttons (fire and menu);
+// this way we get persistence "for free", as the old gamepadButtons
+// configuration is stored in the CONFIG.CK? files
 int16_t in_gamepadButtons[4];
 
 IN_ScanCode *in_key_controls[] = {
@@ -157,6 +157,7 @@ static IN_Direction in_dirTable[] = // Quick lookup for total direction
 		IN_dir_SouthWest, IN_dir_South, IN_dir_SouthEast};
 
 bool in_joyAdvancedMotion = true;
+int16_t in_joyDeadzonePercent = 30;
 static int in_joyCachedDeadzone = 0;
 static int in_joyScaledDeadzone = 0;
 
@@ -502,9 +503,9 @@ void In_GetJoyMotion(int joystick, IN_Motion *p_x, IN_Motion *p_y)
 	int valX, valY, resX, resY, signX, signY;
 
 	// update the pre-computed deadzone threshold
-	if (in_gamepadButtons[(int)IN_joy_deadzone] != in_joyCachedDeadzone)
+	if (in_joyDeadzonePercent != in_joyCachedDeadzone)
 	{
-		in_joyCachedDeadzone = in_gamepadButtons[(int)IN_joy_deadzone];
+		in_joyCachedDeadzone = in_joyDeadzonePercent;
 		in_joyScaledDeadzone = (in_backend->joyAxisMax - in_backend->joyAxisMin) * in_joyCachedDeadzone / 200;
 		in_joyScaledDeadzone *= in_joyScaledDeadzone;
 	}
@@ -607,6 +608,7 @@ void IN_ReadControls(int player, IN_ControlFrame *controls)
 	controls->jump = false;
 	controls->pogo = false;
 	controls->button2 = false;
+	controls->button3 = false;
 
 	if (in_demoState == IN_Demo_Playback)
 	{
@@ -680,6 +682,7 @@ void IN_ReadControls(int player, IN_ControlFrame *controls)
 			controls->jump = IN_GetJoyButtonFromMask(buttons, IN_joy_jump);
 			controls->pogo = IN_GetJoyButtonFromMask(buttons, IN_joy_pogo);
 			controls->button2 = IN_GetJoyButtonFromMask(buttons, IN_joy_fire);
+			controls->button3 = IN_GetJoyButtonFromMask(buttons, IN_joy_menu);
 		}
 
 		controls->dir = in_dirTable[3 * (controls->yDirection + 1) + controls->xDirection + 1];
@@ -795,15 +798,33 @@ bool IN_UserInput(int tics, bool waitPress)
 
 int IN_GetJoyConf(IN_JoyConfItem item)
 {
-	return ((item >= IN_joy_min_) && (item <= IN_joy_max_))
-		? in_gamepadButtons[(int)item]
-		: 0;
+	switch (item)
+	{
+		case IN_joy_deadzone:
+			return in_joyDeadzonePercent;
+		case IN_joy_modern:
+			return in_joyAdvancedMotion ? 1 : 0;
+		default:
+			return ((item >= IN_joy_button_min_) && (item <= IN_joy_button_max_))
+				? in_gamepadButtons[(int)item]
+				: 0;
+	}
 }
 
 void IN_SetJoyConf(IN_JoyConfItem item, int value)
 {
-	if ((item >= IN_joy_min_) && (item <= IN_joy_max_))
-		in_gamepadButtons[(int)item] = (int16_t)value;
+	switch (item)
+	{
+		case IN_joy_deadzone:
+			in_joyDeadzonePercent = (int16_t)value;
+			break;
+		case IN_joy_modern:
+			in_joyAdvancedMotion = (value != 0);
+			break;
+		default:
+			if ((item >= IN_joy_button_min_) && (item <= IN_joy_button_max_))
+				in_gamepadButtons[(int)item] = (int16_t)value;
+	}
 }
 
 bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn)

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -262,9 +262,11 @@ typedef enum IN_JoyConfItem
 	IN_joy_jump = 0,
 	IN_joy_pogo = 1,
 	IN_joy_fire = 2,
-	IN_joy_deadzone = 3,
-	IN_joy_min_ = IN_joy_jump,
-	IN_joy_max_ = IN_joy_deadzone
+	IN_joy_menu = 3,
+	IN_joy_deadzone = 4,	// not saved in CONFIG.CKx
+	IN_joy_modern = 5,	// not saved in CONFIG.CKx
+	IN_joy_button_min_ = IN_joy_jump,
+	IN_joy_button_max_ = IN_joy_menu,
 } IN_JoyConfItem;
 
 void IN_PumpEvents();

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -380,8 +380,10 @@ bool US_LineInput(uint16_t x, uint16_t y, char *buf, char *def, bool escok, uint
 		cursorvis, cursormoved,
 		done, result;
 	IN_ScanCode sc;
+#ifndef CK_VANILLA
 	IN_Cursor joystate;
 	IN_ScanCode joykey = IN_SC_None;
+#endif
 	char c,
 		s[128], olds[128];
 	uint16_t i,
@@ -419,6 +421,7 @@ bool US_LineInput(uint16_t x, uint16_t y, char *buf, char *def, bool escok, uint
 		c = IN_GetLastASCII();
 		IN_SetLastASCII(IN_KP_None);
 
+#ifndef CK_VANILLA
 		IN_ReadCursor(&joystate);
 		if (joystate.button0)
 			joykey = IN_SC_Enter;
@@ -426,6 +429,7 @@ bool US_LineInput(uint16_t x, uint16_t y, char *buf, char *def, bool escok, uint
 			joykey = IN_SC_Escape;
 		if (!joystate.button0 && !joystate.button1 && (sc == IN_SC_None))
 			sc = joykey;
+#endif
 
 		switch (sc)
 		{

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -380,6 +380,8 @@ bool US_LineInput(uint16_t x, uint16_t y, char *buf, char *def, bool escok, uint
 		cursorvis, cursormoved,
 		done, result;
 	IN_ScanCode sc;
+	IN_Cursor joystate;
+	IN_ScanCode joykey = IN_SC_None;
 	char c,
 		s[128], olds[128];
 	uint16_t i,
@@ -416,6 +418,14 @@ bool US_LineInput(uint16_t x, uint16_t y, char *buf, char *def, bool escok, uint
 		IN_SetLastScan(IN_SC_None);
 		c = IN_GetLastASCII();
 		IN_SetLastASCII(IN_KP_None);
+
+		IN_ReadCursor(&joystate);
+		if (joystate.button0)
+			joykey = IN_SC_Enter;
+		if (joystate.button1)
+			joykey = IN_SC_Escape;
+		if (!joystate.button0 && !joystate.button1 && (sc == IN_SC_None))
+			sc = joykey;
 
 		switch (sc)
 		{

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -728,7 +728,7 @@ void US_LoadConfig(void)
 		in_gamepadButtons[0] = 0;
 		in_gamepadButtons[1] = 1;
 		in_gamepadButtons[2] = -1;
-		in_gamepadButtons[3] = 30;
+		in_gamepadButtons[3] = -1;
 		//ck_highScoresDirty = 1; // Unused?
 	}
 	SD_Default(configFileLoaded && (hadAdlib == AdLibPresent), sd, sm);

--- a/src/id_us_2.c
+++ b/src/id_us_2.c
@@ -1014,6 +1014,7 @@ void US_RunCards()
 			IN_Cursor cursor;
 			IN_ReadCursor(&cursor);
 
+#ifndef CK_VANILLA
 			if (cursor.yMotion != prev_controller_motion)
 			{
 				// when pushing the controller,
@@ -1021,6 +1022,7 @@ void US_RunCards()
 				controller_dy = cursor.yMotion * 40;
 			}
 			else
+#endif
 			{
 				controller_dy += cursor.yMotion;
 			}

--- a/src/id_us_2.c
+++ b/src/id_us_2.c
@@ -51,6 +51,9 @@ void CK_US_SetJoyBinding(US_CardItem *item, IN_JoyConfItem which_control);
 // Card stack can have at most 7 cards
 #define US_MAX_CARDSTACK 7
 
+// Menu motion repeat rate when using a controller (lower value = faster)
+#define US_MENU_MOTION_SPEED 40
+
 extern CK_Difficulty ck_startingDifficulty;
 int game_unsaved, game_in_progress, quit_to_dos, load_game_error;
 
@@ -907,6 +910,7 @@ void USL_EnterCurrentItem()
 void US_RunCards()
 {
 	int16_t controller_dy;
+	int16_t prev_controller_motion;
 	uint32_t cursor_time;
 	US_CardItem *item;
 	//ControlInfo status;
@@ -923,6 +927,7 @@ void US_RunCards()
 	US_DrawCards();
 
 	controller_dy = 0;
+	prev_controller_motion = 0;
 	command_confirmed = 0;
 	cursor = 1;
 	action_taken = true;
@@ -1009,7 +1014,17 @@ void US_RunCards()
 			IN_Cursor cursor;
 			IN_ReadCursor(&cursor);
 
-			controller_dy += cursor.yMotion;
+			if (cursor.yMotion != prev_controller_motion)
+			{
+				// when pushing the controller,
+				// move one menu item immediately
+				controller_dy = cursor.yMotion * 40;
+			}
+			else
+			{
+				controller_dy += cursor.yMotion;
+			}
+			prev_controller_motion = cursor.yMotion;
 
 			if (cursor.button0)
 			{
@@ -1033,15 +1048,15 @@ void US_RunCards()
 				USL_UpLevel();
 				action_taken = true;
 			}
-			else if (controller_dy < -40)
+			else if (controller_dy < -US_MENU_MOTION_SPEED)
 			{
-				controller_dy += 40;
+				controller_dy += US_MENU_MOTION_SPEED;
 				US_SelectPrevItem();
 				action_taken = true;
 			}
-			else if (controller_dy > 40)
+			else if (controller_dy > US_MENU_MOTION_SPEED)
 			{
-				controller_dy -= 40;
+				controller_dy -= US_MENU_MOTION_SPEED;
 				US_SelectNextItem();
 				action_taken = true;
 			}


### PR DESCRIPTION
This patch series makes all essential parts of Omnispeak controllable with a joystick:
- The Terminator intro can be dismissed with a joystick button (7d7c946).
- Joystick controls for the menu have been improved (f447a9b, 4d40bb6).
- A button for returning to the menu from the game can now be mapped (e81bb25).
- Saving is possible without a keyboard (ad73f93).

In other words, you can play Omnispeak without requiring a keyboard now, which is quite nice e.g. for RetroPie setups.

Caveats:
- Many non-essential screens can still not be dismissed with the joystick (demos, intro scroller, Paddle War).
- The joystick needs to be enabled and configured using the keyboard at least once initially.
- To make room for the "menu" button configuration, the mapping of the configuration file item `in_gamepadButtons` had to be changed again. As a result, the deadzone is now no longer stored; if you want anything other than 30%, you need to re-adjust it every time you launch Omnispeak.