### PR TITLE
WIP Add cross-compilation build for RG350

### DIFF
--- a/README
+++ b/README
@@ -71,6 +71,9 @@ the files from the 'data' directories.
 Cross-compilation for 32-bit and 64-bit Windows targets using MinGW32-Win64
 is also supported.
 
+Cross-compilation for the RG350 is supported using BuildRoot. Configure it
+before building by running the prebuild-rg350.sh script in the tools folder.
+
 To see a full list of build options, just run `make help`.
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ This Makefile supports the following options:
                   win32   = MinGW cross-build for 32-bit Windows
                   win64   = MinGW cross-build for 64-bit Windows
                   dos     = DJGPP cross-build for DOS (with DOS Extender)
+                  rg350   = OpenDingux cross-build for RetroGame 350
 
   RENDERER      the type of video output API (not available for PLATFORM=dos)
 		  sdl1    = SDL 1.2 (deprecated; no win64 support)
@@ -74,6 +75,7 @@ DEFAULT_LOCAL_SDL = 0
 BINDIR =
 LIBGL = -lGL
 LIBVULKAN = -lvulkan
+SDL_CONFIG_PREFIX =
 OUTDIR_SUFFIX := INVALID
 
 ifeq ($(PLATFORM),)
@@ -104,6 +106,16 @@ ifeq ($(PLATFORM), dos)
 	TOOLDIR = /usr/local/djgpp/bin
 	DEFAULT_RENDERER = dos
 	DEFAULT_BUILDASCPP = 1
+endif
+
+ifeq ($(PLATFORM), rg350)
+        BUILDROOT_DIR = ../buildroot-rg350
+        OUTDIR_SUFFIX := -rg350
+        TOOLSET = mipsel-gcw0-linux-uclibc
+        TOOLDIR = ${BUILDROOT_DIR}/output/host/usr/bin
+        DEFAULT_RENDERER = sdl2
+        SDL_CONFIG_PREFIX = ${BUILDROOT_DIR}/output/host/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/bin/
+        DEFAULT_BUILDASCPP = 1
 endif
 
 ifeq ($(OUTDIR_SUFFIX),INVALID)
@@ -215,12 +227,12 @@ endif
 
 # set parameters that depend on the SDL version (1/2)
 ifeq ($(RENDERER), sdl1)
-	SDL_CONFIG_BIN = sdl-config
+	SDL_CONFIG_BIN = $(SDL_CONFIG_PREFIX)sdl-config
 	SDL_VERSION = $(SDL1_VERSION)
 	SDL_URL = http://libsdl.org/release/SDL-devel-$(SDL_VERSION)-mingw32.tar.gz
 	SDL_LOCAL_PREFIX = SDL-$(SDL_VERSION)
 else
-	SDL_CONFIG_BIN = sdl2-config
+	SDL_CONFIG_BIN = $(SDL_CONFIG_PREFIX)sdl2-config
 	SDL_VERSION = $(SDL2_VERSION)
 	SDL_URL = http://libsdl.org/release/SDL2-devel-$(SDL_VERSION)-mingw.tar.gz
 	SDL_LOCAL_PREFIX = SDL2-$(SDL_VERSION)/$(TOOLSET)
@@ -242,6 +254,11 @@ endif
 ifneq (,$(findstring win,$(PLATFORM)))
 	BATFILES = $(BINDIR)/_keen4.cmd $(BINDIR)/_keen5.cmd $(BINDIR)/_keen6.cmd
 	RES = $(OBJDIR)/windowsres.res
+endif
+
+# set RG350-specific parameters
+ifeq ($(PLATFORM), rg350)
+        RG350_SHELLFILES = $(BINDIR)/keen4.sh $(BINDIR)/keen5.sh $(BINDIR)/keen6.sh
 endif
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -286,7 +303,7 @@ OBJ += $(CKOBJECTS:%=$(OBJDIR)/%)
 OBJ += $(OPLOBJECTS:%=$(OBJDIR)/%)
 DEPS := $(OBJ:%.o=%.d)
 
-all: $(OUTBIN) binfiles batfiles
+all: $(OUTBIN) binfiles batfiles rg350_shellfiles
 
 help:
 	$(info $(HELP))
@@ -354,12 +371,21 @@ $(BINDIR)/_keen5.cmd:
 $(BINDIR)/_keen6.cmd:
 	echo -n "start omnispeak.exe /EPISODE 6 /NOWAIT" >$@
 
+# generate shell scripts for RG350 to start specific episodes
+rg350_shellfiles: $(RG350_SHELLFILES)
+$(BINDIR)/keen4.sh:
+	echo -n "env SDL_RENDER_DRIVER=software ./omnispeak /EPISODE 4 /FULLSCREEN /NOBORDER" >$@
+$(BINDIR)/keen5.sh:
+	echo -n "env SDL_RENDER_DRIVER=software ./omnispeak /EPISODE 5 /FULLSCREEN /NOBORDER" >$@
+$(BINDIR)/keen6.sh:
+	echo -n "env SDL_RENDER_DRIVER=software ./omnispeak /EPISODE 6 /FULLSCREEN /NOBORDER /NOCOPY" >$@
+
 # auto-download of SDL
 $(SDL_DIR):
 	wget -O- $(SDL_URL) | tar xz -C ..
 
 clean:
-	rm -f $(OUTBIN) $(OBJ) $(OBJDIR)/windowsres.res $(DEPS) $(K4DATA) $(K5DATA) $(K6DATA) $(BATFILES)
+	rm -f $(OUTBIN) $(OBJ) $(OBJDIR)/windowsres.res $(DEPS) $(K4DATA) $(K5DATA) $(K6DATA) $(BATFILES) $(RG350_SHELLFILES)
 
 RMDIR_ERRMSG = Note: Some of the 'bin' directories still contain user data. They have not been removed.
 export RMDIR_ERRMSG
@@ -371,4 +397,4 @@ distclean:
 
 -include $(DEPS)
 
-.PHONY: all help dumpconfig binfiles batfiles keen4data keen5data keen6data clean distclean
+.PHONY: all help dumpconfig binfiles batfiles rg350_shellfiles keen4data keen5data keen6data clean distclean

--- a/tools/prebuild-rg350.sh
+++ b/tools/prebuild-rg350.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script checks out and configures buildroot for RG350.
+# This only needs to be run once in order to build omnispeak for RG350.
+BUILDROOT_GIT=https://github.com/tonyjih/RG350_buildroot.git
+BUILDROOT_DIR=`dirname "$0"`/../buildroot-rg350
+
+echo "Cloning BuildRoot..."
+git clone --depth=1 "${BUILDROOT_GIT}" "${BUILDROOT_DIR}"
+cd "${BUILDROOT_DIR}"
+
+echo "Configuring BuildRoot..."
+make rg350_defconfig BR2_EXTERNAL=board/opendingux
+
+echo "Building toochain..."
+BR2_JLEVEL=0 make toolchain sdl2
+
+echo "All done!"
+cd -
+
+
+


### PR DESCRIPTION
I'm not sure if you want this sort of thing in the main repo, but this adds a build configuration for the RG350 (OpenDingux-based handheld). I set this up for myself but figured I should share it. I tidied this up a little before putting it up, but admittedly it's probably still a little rough so I'm open to changes.

I set this up in a similar way to [devilutionX](https://github.com/diasurgical/devilutionX/blob/master/Packaging/OpenDingux)'s build for RG350, which checks out a copy of BuildRoot and configures it for RG350, building the toochain and any packages needed for the build. In this case, I've set up a "prebuild-rg350.sh" script (in the tools dir) that checks out BuildRoot for RG350, configures it, then builds the toolchain and sdl2.

I made changes to the Makefile to add a new "rg350" PLATFORM type. This assumes the directory created by the pre-build script exists, and sets the TOOLSET and TOOLDIR appropriately. I also prefixed SDL_CONFIG with a path to sdl2-config in the BuildRoot output.

Lastly, the Makefile also generates shell scripts to launch each episode. This is a convenient way to make sure the SDL_RENDER_DRIVER environment variable is set to "software" for the process, but also makes it easy to set up shortcuts for each episode on the RG350. Note that I also added /NOCOPY to the Keen 6 script since there is no way to enter text to identify the creatures in the prompt.

I tested this by running the pre-build script in a fresh checkout of this fork/branch on Ubuntu 20.04, and called "make PLATFORM=rg350" from the src/ directory. I copied the build output to my RG350M and tried launching each episode using the scripts. I've been playing Keen 4 for a little while using this build and it works rather well. I tried running a vanilla "make" command as well to make sure the default Linux build still worked. I haven't tried any of this stuff in a Windows/MinGW/Cygwin environment.