### PR TITLE
Add cross-build for GCW Zero

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -15,6 +15,9 @@ jobs:
         sudo apt install libsdl2-dev mingw-w64
         wget https://github.com/andrewwutw/build-djgpp/releases/download/v2.9/djgpp-linux64-gcc550.tar.bz2
         sudo tar xf djgpp-linux64-gcc550.tar.bz2 -C /usr/local
+        sudo mkdir -p /opt
+        wget http://www.gcw-zero.com/files/opendingux-gcw0-toolchain.2014-08-20.tar.bz2
+        sudo tar xf opendingux-gcw0-toolchain.2014-08-20.tar.bz2 -C /opt
     - name: Build (Linux)
       working-directory: ./src
       run: |
@@ -28,6 +31,10 @@ jobs:
       working-directory: ./src
       run: |
         make PLATFORM=dos
+    - name: Build (GCW Zero)
+      working-directory: ./src
+      run: |
+        make PLATFORM=gcw0
     - name: Upload (Linux)
       uses: actions/upload-artifact@v2
       with:
@@ -43,3 +50,8 @@ jobs:
       with:
         name: MS-DOS Build
         path: bin-dos/
+    - name: Upload (GCW Zero)
+      uses: actions/upload-artifact@v2
+      with:
+        name: GCW Zero Build
+        path: bin-gcw0/

--- a/README
+++ b/README
@@ -83,6 +83,8 @@ the files from the 'data' directories.
 Cross-compilation for 32-bit and 64-bit Windows targets using MinGW32-Win64
 is also supported.
 
+Cross-compilation for GCW Zero possible using the [GCW Zero toolchain](http://www.gcw-zero.com/develop).
+
 To see a full list of build options, just run `make help`.
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -125,6 +125,8 @@ ifeq ($(PLATFORM), gcw0)
         DEFAULT_RENDERER = sdl2sw
         SDL_CONFIG_PREFIX = $(GCW0_TOOLCHAIN_DIR)/usr/$(TOOLSET)/sysroot/usr/bin/
         DEFAULT_BUILDASCPP = 1
+        # HACK: gcw0 misel architecture doesn't define O_PATH
+        CXXFLAGS += -DO_PATH=010000000
 endif
 
 ifeq ($(OUTDIR_SUFFIX),INVALID)

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ This Makefile supports the following options:
                   win32   = MinGW cross-build for 32-bit Windows
                   win64   = MinGW cross-build for 64-bit Windows
                   dos     = DJGPP cross-build for DOS (with DOS Extender)
+                  gcw0    = OpenDingux cross-build for GCW Zero
 
   RENDERER      the type of video output API (not available for PLATFORM=dos)
 		  sdl1    = SDL 1.2 (deprecated; no win64 support)
@@ -83,6 +84,7 @@ LIBGL = -lGL
 LIBVULKAN = -lvulkan
 LIBASOUND = -lasound
 LIBIEEE1284 = -lieee1284
+SDL_CONFIG_PREFIX =
 OUTDIR_SUFFIX := INVALID
 
 ifeq ($(PLATFORM),)
@@ -113,6 +115,16 @@ ifeq ($(PLATFORM), dos)
 	TOOLDIR = /usr/local/djgpp/bin
 	DEFAULT_RENDERER = dos
 	DEFAULT_BUILDASCPP = 1
+endif
+
+ifeq ($(PLATFORM), gcw0)
+        OUTDIR_SUFFIX := -gcw0
+        GCW0_TOOLCHAIN_DIR = /opt/gcw0-toolchain
+        TOOLSET = mipsel-gcw0-linux-uclibc
+        TOOLDIR = $(GCW0_TOOLCHAIN_DIR)/usr/bin
+        DEFAULT_RENDERER = sdl2sw
+        SDL_CONFIG_PREFIX = $(GCW0_TOOLCHAIN_DIR)/usr/$(TOOLSET)/sysroot/usr/bin/
+        DEFAULT_BUILDASCPP = 1
 endif
 
 ifeq ($(OUTDIR_SUFFIX),INVALID)
@@ -224,12 +236,12 @@ endif
 
 # set parameters that depend on the SDL version (1/2)
 ifeq ($(RENDERER), sdl1)
-	SDL_CONFIG_BIN = sdl-config
+	SDL_CONFIG_BIN = $(SDL_CONFIG_PREFIX)sdl-config
 	SDL_VERSION = $(SDL1_VERSION)
 	SDL_URL = http://libsdl.org/release/SDL-devel-$(SDL_VERSION)-mingw32.tar.gz
 	SDL_LOCAL_PREFIX = SDL-$(SDL_VERSION)
 else
-	SDL_CONFIG_BIN = sdl2-config
+	SDL_CONFIG_BIN = $(SDL_CONFIG_PREFIX)sdl2-config
 	SDL_VERSION = $(SDL2_VERSION)
 	SDL_URL = http://libsdl.org/release/SDL2-devel-$(SDL_VERSION)-mingw.tar.gz
 	SDL_LOCAL_PREFIX = SDL2-$(SDL_VERSION)/$(TOOLSET)
@@ -254,6 +266,12 @@ ifneq (,$(findstring win,$(PLATFORM)))
 	# MS Bitfields has a bug with packed structures on some GCC versions:
 	# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
 	CXXFLAGS += -mno-ms-bitfields
+endif
+
+# set GCW Zero-specific parameters
+ifeq ($(PLATFORM), gcw0)
+        SHELLFILES = $(BINDIR)/keen4.sh $(BINDIR)/keen5.sh $(BINDIR)/keen6.sh
+        SHELLOPTS = /FULLSCREEN /NOBORDER /NOCOPY
 endif
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -315,7 +333,7 @@ OBJ += $(CKOBJECTS:%=$(OBJDIR)/%)
 OBJ += $(OPLOBJECTS:%=$(OBJDIR)/%)
 DEPS := $(OBJ:%.o=%.d)
 
-all: $(OUTBIN) binfiles batfiles
+all: $(OUTBIN) binfiles batfiles shellfiles
 
 help:
 	$(info $(HELP))
@@ -383,12 +401,21 @@ $(BINDIR)/_keen5.cmd:
 $(BINDIR)/_keen6.cmd:
 	echo -n "start omnispeak.exe /EPISODE 6 /NOWAIT" >$@
 
+# generate shell scripts to start specific episodes
+shellfiles: $(SHELLFILES)
+$(BINDIR)/keen4.sh:
+	echo -n "./omnispeak /EPISODE 4 $(SHELLOPTS)" >$@
+$(BINDIR)/keen5.sh:
+	echo -n "./omnispeak /EPISODE 5 $(SHELLOPTS)" >$@
+$(BINDIR)/keen6.sh:
+	echo -n "./omnispeak /EPISODE 6 $(SHELLOPTS)" >$@
+
 # auto-download of SDL
 $(SDL_DIR):
 	wget -O- $(SDL_URL) | tar xz -C ..
 
 clean:
-	rm -f $(OUTBIN) $(OBJ) $(OBJDIR)/windowsres.res $(DEPS) $(K4DATA) $(K5DATA) $(K6DATA) $(BATFILES)
+	rm -f $(OUTBIN) $(OBJ) $(OBJDIR)/windowsres.res $(DEPS) $(K4DATA) $(K5DATA) $(K6DATA) $(BATFILES) $(SHELLFILES)
 
 RMDIR_ERRMSG = Note: Some of the 'bin' directories still contain user data. They have not been removed.
 export RMDIR_ERRMSG
@@ -400,4 +427,4 @@ distclean:
 
 -include $(DEPS)
 
-.PHONY: all help dumpconfig binfiles batfiles keen4data keen5data keen6data clean distclean
+.PHONY: all help dumpconfig binfiles batfiles shellfiles keen4data keen5data keen6data clean distclean


### PR DESCRIPTION
This adds a build configuration for the [GCW Zero](http://www.gcw-zero.com/) (OpenDingux-based handheld). I set this up for myself to run Omnispeak on my RG350M but figured I should share it.

I made changes to the Makefile to add a new "gcw0" PLATFORM type. This assumes the [GCW Zero toolchain](http://www.gcw-zero.com/develop) exists in its preferred default location, and sets the TOOLSET and TOOLDIR appropriately. I also prefixed SDL_CONFIG with a path to sdl2-config in the toolchain directory. This uses the software rendering option you just added, so thanks for adding that!

Lastly, the Makefile also generates shell scripts to launch each episode. This is a convenient way to set appropriate command line options for a low-resolution fullscreen environment with no keyboard, but also makes it easy to set up shortcuts for each episode on an OpenDingux handheld. I separated these extra options in their own variable in case we want to reuse these scripts in other Unix environments.

I updated the CI to build GCW Zero binaries as well, so that this can be on-par with the other supported platforms.

I tested this by building on my Ubuntu 20.04 machine using "make PLATFORM=gcw0" from the src/ directory. I copied the build output to my RG350M and tried launching each episode using the scripts. I played a few levels of Keen 4. I tried running a vanilla "make" command as well to make sure the default Linux build still worked. I tested out the binaries produced by the CI task and those work just as well.

I don't have any other physical devices to try this on, but in theory this should work on a GCW Zero or any other device based on it. I tried to set up a GCW Zero VM using QEMU using [this guide](http://prizma.bmstu.ru/~exmortis/posts/2015-05-02-gcw0-qemu.html) but wasn't able to build the toolchain. :(