### PR TITLE
CI: Update the djgpp version to GCC 10.2.0

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -13,8 +13,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libsdl2-dev mingw-w64
-        wget https://github.com/andrewwutw/build-djgpp/releases/download/v2.9/djgpp-linux64-gcc550.tar.bz2
-        sudo tar xf djgpp-linux64-gcc550.tar.bz2 -C /usr/local
+        wget https://github.com/andrewwutw/build-djgpp/releases/download/v3.1/djgpp-linux64-gcc1020.tar.bz2
+        sudo tar xf djgpp-linux64-gcc1020.tar.bz2 -C /usr/local
     - name: Build (Linux)
       working-directory: ./src
       run: |


### PR DESCRIPTION
No sense using something old if the new version works. Particularly
given that we have had issues with old gcc versions for win32 in the
past.