### PR TITLE
Add a new config file system

### DIFF
--- a/README
+++ b/README
@@ -59,7 +59,8 @@ You can provide Omnispeak the following command-line arguments:
 		- Bypasses the "Creature Question" screen in Keen 6.
 	/NOAUDIOSYNC
 		- When using SDL-based sound backends, use the system clock
-		  rather than the audio clock.
+		  rather than the audio clock. Available as the
+		  'sd_sdl_noAudioSync' config option.
 		  (Works around issues with some SDL audio backends under wine)
 	/DEMOFILE <filename>
 		- Plays the demo recorded with Keen's F10+D cheat in filename.
@@ -70,9 +71,14 @@ Omnispeak can read settings from the 'OMNISPK.CFG' file in the "user path".
 This is a simple key/value file which looks something like this:
 
 --8<--
+# Graphics settings
 fullscreen = 1
 border = 1
 integer = 0
+
+# The OPL emulator used by the SDL audio backend
+# Valid values: "dbopl" (DOSBox), "nukedopl3" (NukedOPL3)
+oplEmulator = "dbopl"
 --8<--
 
 Modifying settings from the ComputerWrist interface will update this config

--- a/README
+++ b/README
@@ -64,6 +64,22 @@ You can provide Omnispeak the following command-line arguments:
 	/DEMOFILE <filename>
 		- Plays the demo recorded with Keen's F10+D cheat in filename.
 
+== CONFIGURATION ==
+
+Omnispeak can read settings from the 'OMNISPK.CFG' file in the "user path".
+This is a simple key/value file which looks something like this:
+
+--8<--
+fullscreen = 1
+border = 1
+integer = 0
+--8<--
+
+Modifying settings from the ComputerWrist interface will update this config
+file with the new settings.
+
+Note that this file is not episode-specific. The settings are shared between
+all episodes.
 
 == COMPILING ==
 
@@ -105,7 +121,4 @@ To see a full list of build options, just run `make help`.
 - Modding support is not implemented.
 - Mouse support is not implemented.
 - Some debug cheats are not supported.
-- New settings ("Fullscreen", "Aspect Ratio", "Overscan border") are not saved.
-- The game always redraws everything every frame.
 - Some chunks are not cached properly at load time (doors, especially)
-- No fallbacks for systems without GLSL and non-power-of-two texture support.

--- a/README
+++ b/README
@@ -110,7 +110,10 @@ Cross-compilation for GCW Zero possible using the [GCW Zero toolchain](http://ww
 On Linux, real OPL2 compatible soundcards can be used in place of the Adlib
 emulation by building with either the WITH_ALSA=1 option (for most soundcards),
 or the WITH_IEEE1284=1 option (for the OPL2LPT). These require libasound and libieee1284
-respectively, and must be enabled at runtime with a command-line option.
+respectively, and must be enabled at runtime by setting the "sd_backend" option
+to "alsa" or "opl2lpt". (The ALSA device can be configured with the
+"sd_alsa_device" option, and the parallel port for the OPL2LPT can be set with
+"sd_opl2lpt_port".)
 
 Packagers should note that it's possible to change the default KEEN and USER
 paths with the make KEENPATH= and make USERPATH= options. Similarly, savegames

--- a/src/Makefile
+++ b/src/Makefile
@@ -180,7 +180,7 @@ LDFLAGS ?=
 LIBS ?=
 
 # mandatory source files
-IDOBJECTS = ck_quit.o id_mm.o id_fs.o id_ca.o id_in.o id_rf.o id_sd.o id_ti.o id_us_1.o id_us_2.o id_us_textscreen.o id_vh.o id_vl.o id_str.o
+IDOBJECTS = ck_quit.o id_mm.o id_fs.o id_ca.o id_cfg.o id_in.o id_rf.o id_sd.o id_ti.o id_us_1.o id_us_2.o id_us_textscreen.o id_vh.o id_vl.o id_str.o
 CKOBJECTS = ck_act.o ck_inter.o ck_keen.o ck_obj.o ck_map.o ck4_map.o ck5_map.o ck6_map.o ck4_obj1.o ck4_obj2.o ck4_obj3.o ck5_obj1.o ck5_obj2.o ck5_obj3.o ck6_obj1.o ck6_obj2.o ck6_obj3.o ck_phys.o ck_game.o ck_play.o ck_misc.o ck4_misc.o ck5_misc.o ck6_misc.o ck_main.o ck_text.o ck_cross.o icon.o
 OPLOBJECTS = opl/dbopl.o opl/nuked_opl3.o
 

--- a/src/ck_main.c
+++ b/src/ck_main.c
@@ -273,6 +273,8 @@ void CK_ShutdownID(void)
 	//VH
 	VL_Shutdown();
 	CA_Shutdown();
+
+	CFG_Shutdown();
 	MM_Shutdown();
 
 #ifdef WITH_SDL
@@ -286,11 +288,6 @@ void CK_ShutdownID(void)
 
 void CK_InitGame()
 {
-	// Can't do much without memory!
-	MM_Startup();
-
-	//TODO: Get filenames/etc from config/episode
-
 	// Load the core datafiles
 	CA_Startup();
 	// Setup saved games handling
@@ -643,6 +640,12 @@ int main(int argc, char *argv[])
 	// for any files.
 	FS_Startup();
 
+	// Can't do much without memory!
+	MM_Startup();
+
+	// Load the config file. We do this before parsing command-line args.
+	CFG_Startup();
+
 	// Default to the first episode with all files present.
 	// If no episodes are found, we default to Keen 4, in order
 	// to show the file not found messages.
@@ -656,11 +659,11 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	bool isFullScreen = false;
-	bool isAspectCorrected = true;
-	bool hasBorder = true;
-	bool isIntegerScaled = false;
-	bool overrideCopyProtection = false;
+	bool isFullScreen = CFG_GetConfigInt("fullscreen", 0);
+	bool isAspectCorrected = CFG_GetConfigInt("aspect", 1);
+	bool hasBorder = CFG_GetConfigInt("border", 1);
+	bool isIntegerScaled = CFG_GetConfigInt("integer", 0);
+	bool overrideCopyProtection = CFG_GetConfigInt("ck6_noCreatureQuestion", 0);
 #ifdef CK_ENABLE_PLAYLOOP_DUMPER
 	const char *dumperFilename = NULL;
 #endif

--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -88,6 +88,8 @@ bool CK_US_FullscreenMenuProc(US_CardMsg msg, US_CardItem *item)
 		return false;
 
 	VL_ToggleFullscreen();
+	// Save the config option.
+	CFG_SetConfigInt("fullscreen", vl_isFullScreen);
 	USL_CtlDialog((vl_isFullScreen ? "Fullscreen mode enabled" : "Windowed mode enabled"), "Press any key", NULL);
 	CK_US_UpdateOptionsMenus();
 	return true;
@@ -99,6 +101,7 @@ bool CK_US_AspectCorrectMenuProc(US_CardMsg msg, US_CardItem *item)
 		return false;
 
 	VL_ToggleAspect();
+	CFG_SetConfigInt("aspect", vl_isAspectCorrected);
 	USL_CtlDialog((vl_isAspectCorrected ? "Aspect ratio correction now on" : "Aspect ratio correction now off"), "Press any key", NULL);
 	CK_US_UpdateOptionsMenus();
 	return true;
@@ -110,6 +113,7 @@ bool CK_US_BorderMenuProc(US_CardMsg msg, US_CardItem *item)
 		return false;
 
 	VL_ToggleBorder();
+	CFG_SetConfigInt("border", vl_hasOverscanBorder);
 	USL_CtlDialog((vl_hasOverscanBorder ? "Overscan border now on" : "Overscan border now off"), "Press any key", NULL);
 	CK_US_UpdateOptionsMenus();
 	return true;
@@ -121,6 +125,7 @@ bool CK_US_IntegerMenuProc(US_CardMsg msg, US_CardItem *item)
 		return false;
 
 	VL_ToggleInteger();
+	CFG_SetConfigInt("integer", vl_isIntegerScaled);
 	USL_CtlDialog((vl_isIntegerScaled ? "Integer scaling now on" : "Integer scaling now off"), "Press any key", NULL);
 	CK_US_UpdateOptionsMenus();
 	return true;

--- a/src/id_cfg.c
+++ b/src/id_cfg.c
@@ -106,7 +106,7 @@ void CFG_LoadConfig(const char *filename)
 	int numVarsParsed = 0;
 	STR_ParserState parserstate;
 
-	FS_LoadFile(filename, (mm_ptr_t *)(&parserstate.data), &(parserstate.datasize));
+	FS_LoadUserFile(filename, (mm_ptr_t *)(&parserstate.data), &(parserstate.datasize));
 	if (!parserstate.data)
 		return;
 
@@ -233,7 +233,7 @@ void CFG_SaveConfig(const char *filename)
 	// Load the old save file.
 	STR_ParserState parserstate;
 
-	FS_LoadFile(filename, (mm_ptr_t *)(&parserstate.data), &(parserstate.datasize));
+	FS_LoadUserFile(filename, (mm_ptr_t *)(&parserstate.data), &(parserstate.datasize));
 	FS_File outputHandle = FS_CreateUserFile(filename);
 	if (parserstate.data)
 	{

--- a/src/id_cfg.c
+++ b/src/id_cfg.c
@@ -1,0 +1,285 @@
+/*
+Omnispeak: A Commander Keen Reimplementation
+Copyright (C) 2021 Omnispeak Authors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "id_cfg.h"
+#include "id_ca.h"
+#include "id_fs.h"
+#include "id_str.h"
+#include "ck_cross.h"
+
+ID_MM_Arena *cfg_configArena;
+STR_Table *cfg_configEntries;
+
+bool CFG_ConfigExists(const char *name)
+{
+	return STR_LookupEntry(cfg_configEntries, name);
+}
+
+int CFG_GetConfigInt(const char *name, int defValue)
+{
+	CFG_Variable *var = (CFG_Variable *)STR_LookupEntry(cfg_configEntries, name);
+	if (!var)
+		return defValue;
+	return var->int_value;
+}
+
+const char *CFG_GetConfigString(const char *name, const char *defValue)
+{
+	CFG_Variable *var = (CFG_Variable *)STR_LookupEntry(cfg_configEntries, name);
+	if (!var)
+		return defValue;
+	return var->str_value;
+}
+
+// Gets or creates a config variable. When created, the name is StrDup'ed into the
+// config arena.
+static CFG_Variable *CFG_GetOrCreateVariable(const char *name)
+{
+	CFG_Variable *var = (CFG_Variable *)STR_LookupEntry(cfg_configEntries, name);
+	if (var)
+		return var;
+
+	var = (CFG_Variable *)MM_ArenaAlloc(cfg_configArena, sizeof(CFG_Variable));
+	const char *allocedName = MM_ArenaStrDup(cfg_configArena, name);
+	var->name = allocedName;
+
+	// We need to initialise this.
+	var->str_value = 0;
+
+	// Insert it into the hashtable
+	STR_AddEntry(cfg_configEntries, allocedName, var);
+	return var;
+}
+
+void CFG_SetConfigInt(const char *name, int value)
+{
+	CFG_Variable *var = CFG_GetOrCreateVariable(name);
+	var->str_value = 0;
+	var->int_value = value;
+}
+
+void CFG_SetConfigString(const char *name, const char *value)
+{
+	CFG_Variable *var = CFG_GetOrCreateVariable(name);
+
+	// We don't want to re-allocate the value if it's the same.
+	if (!var->str_value || strcmp(value, var->str_value))
+		var->str_value = MM_ArenaStrDup(cfg_configArena, value);
+	var->int_value = 0;
+}
+
+static bool CFG_ParseConfigLine(STR_ParserState *state)
+{
+	const char *name = STR_GetIdent(state);
+	if (!name)
+		return false;
+	if (!STR_ExpectToken(state, "="))
+		return false;
+	STR_Token value = STR_PeekToken(state);
+	if (value.tokenType == STR_TOK_EOF)
+		return false;
+	else if (value.tokenType == STR_TOK_String)
+		CFG_SetConfigString(name, STR_GetString(state));
+	else
+		CFG_SetConfigInt(name, STR_GetInteger(state));
+	return true;
+}
+
+void CFG_LoadConfig(const char *filename)
+{
+	int numVarsParsed = 0;
+	STR_ParserState parserstate;
+
+	FS_LoadFile(filename, (mm_ptr_t *)(&parserstate.data), &(parserstate.datasize));
+	if (!parserstate.data)
+		return;
+
+	parserstate.dataindex = 0;
+	parserstate.linecount = 0;
+	parserstate.haveBufferedToken = false;
+
+	parserstate.tempArena = MM_ArenaCreate(4096);
+
+	while (CFG_ParseConfigLine(&parserstate))
+		numVarsParsed++;
+
+	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Parsed %d config options from \"%s\" over %d lines\n", numVarsParsed, filename, parserstate.linecount);
+
+	MM_ArenaDestroy(parserstate.tempArena);
+	MM_FreePtr((mm_ptr_t *)&parserstate.data);
+}
+
+static int cfg_unmodifiedRangeStart = 0;
+static int cfg_unmodifiedRangeEnd = 0;
+
+static void CFG_FlushUnmodifiedRange(FS_File outputHandle, STR_ParserState *state)
+{
+	FS_Write(&state->data[cfg_unmodifiedRangeStart], cfg_unmodifiedRangeEnd - cfg_unmodifiedRangeStart, 1, outputHandle);
+	cfg_unmodifiedRangeStart = cfg_unmodifiedRangeEnd;
+}
+
+static bool CFG_SaveConfigLine(FS_File outputHandle, STR_ParserState *state)
+{
+	// We do some funky stuff here to handle corrupt files as well as
+	// we can:
+	// We update the "unmodified range" so that its end is the beginning
+	// of the name (which is an identifier).
+	//
+	STR_Token nameTok = STR_PeekToken(state);
+	cfg_unmodifiedRangeEnd = nameTok.firstIndex;
+	const char *name = STR_GetString(state);
+	if (!name)
+		return false;
+	if (!STR_ExpectToken(state, "="))
+	{
+		// If we're at the end of the file, the unmodified range should
+		// end at the file's end.
+		cfg_unmodifiedRangeEnd = state->datasize;
+		return false;
+	}
+	STR_Token value = STR_PeekToken(state);
+	if (value.tokenType == STR_TOK_EOF)
+	{
+		// If we're at the end of the file, the unmodified range should
+		// end at the file's end.
+		cfg_unmodifiedRangeEnd = state->datasize;
+		return false;
+	}
+
+	cfg_unmodifiedRangeEnd = value.firstIndex;
+	CFG_FlushUnmodifiedRange(outputHandle, state);
+
+	CFG_Variable *var = (CFG_Variable *)STR_LookupEntry(cfg_configEntries, name);
+	if (!var)
+	{
+		// Just flush the old value out.
+		CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Unexpected entry in config file: \"%s\". Has the config changed since the game was started?", name);
+		cfg_unmodifiedRangeStart = value.firstIndex;
+		cfg_unmodifiedRangeEnd = value.lastIndex;
+		CFG_FlushUnmodifiedRange(outputHandle, state);
+		// Eat the token.
+		STR_GetToken(state);
+	}
+	else if (value.tokenType == STR_TOK_String)
+	{
+		// We don't mind re-writing out strings, so just eat the
+		// old token.
+		STR_GetToken(state);
+		FS_PrintF(outputHandle, "\"%s\"", var->str_value);
+		var->saved = true;
+	}
+	else
+	{
+		int oldValue = STR_GetInteger(state);
+		if (oldValue == var->int_value)
+		{
+			// If the old value matches the new, mark it unmodified.
+			cfg_unmodifiedRangeStart = value.firstIndex;
+			cfg_unmodifiedRangeEnd = value.lastIndex;
+			CFG_FlushUnmodifiedRange(outputHandle, state);
+		}
+		else
+		{
+			// Otherwise, write it out in decimal.
+			FS_PrintF(outputHandle, "%d", var->int_value);
+		}
+		var->saved = true;
+	}
+
+	cfg_unmodifiedRangeStart = cfg_unmodifiedRangeEnd = value.lastIndex;
+
+	return true;
+}
+
+void CFG_SaveConfig(const char *filename)
+{
+	// Saving the config is actually quite (over) complicated. Here's how
+	// it works:
+	// 1. We mark all variables as unsaved.
+	// 2. We re-parse the existing config file, keeping track of the last
+	// "unmodified range". Basically, every byte that's not part of a
+	// "value" is copied exactly as is. Values are re-inserted from the
+	// loaded config. (The exception is integers, which are only
+	// re-inserted if their value differs, in order to preserve the base.
+	// We mark these variables as "saved" when doing so.
+	// 3. We loop over all variables again, and append any unsaved ones
+	// to the file.
+
+	// Mark all variables unsaved.
+	size_t currentVarIndex = 0;
+	CFG_Variable *currentVar;
+	while (currentVar = (CFG_Variable *)STR_GetNextEntry(cfg_configEntries, &currentVarIndex))
+	{
+		currentVar->saved = false;
+	}
+
+	int numVarsSaved = 0;
+	// Load the old save file.
+	STR_ParserState parserstate;
+
+	FS_LoadFile(filename, (mm_ptr_t *)(&parserstate.data), &(parserstate.datasize));
+	FS_File outputHandle = FS_CreateUserFile(filename);
+	if (parserstate.data)
+	{
+		parserstate.dataindex = 0;
+		parserstate.linecount = 0;
+		parserstate.haveBufferedToken = false;
+
+		parserstate.tempArena = MM_ArenaCreate(4096);
+
+		// Go through the file, re-writing the values of all the config vars.
+		while (CFG_SaveConfigLine(outputHandle, &parserstate))
+			numVarsSaved++;
+
+		CFG_FlushUnmodifiedRange(outputHandle, &parserstate);
+
+		MM_ArenaDestroy(parserstate.tempArena);
+		MM_FreePtr((mm_ptr_t *)&parserstate.data);
+	}
+
+	// Now, loop over the remaining variables and write them out.
+	currentVarIndex = 0;
+	while (currentVar = (CFG_Variable *)STR_GetNextEntry(cfg_configEntries, &currentVarIndex))
+	{
+		if (currentVar->saved)
+			continue;
+
+		if (currentVar->str_value)
+			FS_PrintF(outputHandle, "%s = \"%s\"\n", currentVar->name, currentVar->str_value);
+		else
+			FS_PrintF(outputHandle, "%s = %d\n", currentVar->name, currentVar->int_value);
+	}
+
+	FS_CloseFile(outputHandle);
+}
+
+void CFG_Startup()
+{
+	cfg_configArena = MM_ArenaCreate(4096);
+	STR_AllocTable(&cfg_configEntries, 256);
+
+	CFG_LoadConfig("OMNISPK.CFG");
+}
+
+void CFG_Shutdown()
+{
+	CFG_SaveConfig("OMNISPK.CFG");
+
+	MM_ArenaDestroy(cfg_configArena);
+}

--- a/src/id_cfg.h
+++ b/src/id_cfg.h
@@ -1,6 +1,6 @@
 /*
 Omnispeak: A Commander Keen Reimplementation
-Copyright (C) 2012 David Gow <david@ingeniumdigital.com>
+Copyright (C) 2021 Omnispeak Authors
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -15,19 +15,36 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+ */
 
-#ifndef ID_HEADS_H
-#define ID_HEADS_H
+#ifndef ID_CFG_H
+#define ID_CFG_H
 
-// Header file to include all of the ID-engine
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "id_ca.h"
-#include "id_cfg.h"
-#include "id_in.h"
-#include "id_mm.h"
-#include "id_ti.h"
-#include "id_us.h"
-#include "id_vh.h"
+typedef struct CFG_Variable
+{
+	const char *name;
+	const char *str_value;
+	int int_value;
+	bool saved;
+} CFG_Variable;
 
-#endif //ID_HEADS_H
+void CFG_LoadConfig(const char *filename);
+void CFG_SaveConfig(const char *filename);
+
+bool CFG_ConfigExists(const char *name);
+int CFG_GetConfigInt(const char *name, int defValue);
+const char *CFG_GetConfigString(const char *name, const char *defValue);
+
+void CFG_SetConfigInt(const char *name, int value);
+void CFG_SetConfigString(const char *name, const char *value);
+
+void CFG_Startup();
+void CFG_Shutdown();
+
+#endif

--- a/src/id_fs.c
+++ b/src/id_fs.c
@@ -522,9 +522,9 @@ int FS_PrintF(FS_File stream, const char *fmt, ...)
 	return ret;
 }
 
-bool FS_LoadFile(const char *filename, mm_ptr_t *ptr, int *memsize)
+bool FS_LoadUserFile(const char *filename, mm_ptr_t *ptr, int *memsize)
 {
-	FS_File f = FS_OpenOmniFile(filename);
+	FS_File f = FS_OpenUserFile(filename);
 
 	if (!FS_IsFileValid(f))
 	{

--- a/src/id_fs.h
+++ b/src/id_fs.h
@@ -80,6 +80,6 @@ size_t FS_WriteBoolTo16LE(const void *ptr, size_t count, FS_File stream);
 int FS_PrintF(FS_File stream, const char *fmt, ...);
 
 // Load an entire file into memory.
-bool FS_LoadFile(const char *filename, mm_ptr_t *ptr, int *memsize);
+bool FS_LoadUserFile(const char *filename, mm_ptr_t *ptr, int *memsize);
 
 #endif

--- a/src/id_fs.h
+++ b/src/id_fs.h
@@ -23,8 +23,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // This is the "Filesystem Manager", which handles all file I/O, and determines
 // which paths are used for which data files.
 
-#include <stdio.h>
+#include "id_mm.h"
+
 #include <stdbool.h>
+#include <stdio.h>
 
 typedef FILE *FS_File;
 
@@ -73,5 +75,11 @@ size_t FS_WriteInt32LE(const void *ptr, size_t count, FS_File stream);
 // TODO: Maybe int16_t's should be used internally? (Same as vanilla Keen.)
 size_t FS_ReadBoolFrom16LE(void *ptr, size_t count, FS_File stream);
 size_t FS_WriteBoolTo16LE(const void *ptr, size_t count, FS_File stream);
+
+// fprintf() wrapper.
+int FS_PrintF(FS_File stream, const char *fmt, ...);
+
+// Load an entire file into memory.
+bool FS_LoadFile(const char *filename, mm_ptr_t *ptr, int *memsize);
 
 #endif

--- a/src/id_sd.c
+++ b/src/id_sd.c
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <string.h>
 
 #include "id_ca.h"
+#include "id_cfg.h"
 #include "id_sd.h"
 #include "id_us.h"
 #include "ck_cross.h"
@@ -535,6 +536,17 @@ void SD_Startup()
 		return;
 
 	sd_backend = SD_Impl_GetBackend();
+
+	const char *backendName = CFG_GetConfigString("sd_backend", "default");
+#ifdef SD_OPL2_WITH_ALSA
+	if (!CK_Cross_strcasecmp(backendName, "alsa"))
+		sd_backend = SD_Impl_GetBackend_ALSAOPL2();
+#endif
+#ifdef SD_OPL2_WITH_IEEE1284
+	if (!CK_Cross_strcasecmp(backendName, "opl2lpt"))
+		sd_backend = SD_Impl_GetBackend_OPL2LPT();
+#endif
+
 	for (int i = 0; i < us_argc; ++i)
 	{
 #ifdef SD_OPL2_WITH_ALSA

--- a/src/id_sd_opl2alsa.c
+++ b/src/id_sd_opl2alsa.c
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#include "id_cfg.h"
 #include "id_sd.h"
 #include "id_us.h"
 #include "ck_cross.h"
@@ -245,7 +246,7 @@ static void setupStructs()
 
 void SD_ALSAOPL2_Startup(void)
 {
-	const char *alsaDev = "hw:0,0";
+	const char *alsaDev = CFG_GetConfigString("sd_alsa_device", "hw:0,0");
 	for (int i = 0; i < us_argc; ++i)
 	{
 		if (!CK_Cross_strcasecmp(us_argv[i], "/ALSADEV"))

--- a/src/id_sd_opl2lpt.c
+++ b/src/id_sd_opl2lpt.c
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #endif
 #include <unistd.h>
 
+#include "id_cfg.h"
 #include "id_sd.h"
 #include "id_us.h"
 #include "ck_cross.h"
@@ -151,6 +152,8 @@ void SD_OPL2LPT_PCSpkOn(bool on, int freq)
 void SD_OPL2LPT_Startup(void)
 {
 #ifdef SD_OPL2_WITH_IEEE1284
+	const char *portName = CFG_GetConfigString("sd_opl2lpt_port", "");
+
 	struct parport_list allPorts = {};
 
 	if (ieee1284_find_ports(&allPorts, 0) != E1284_OK)
@@ -159,6 +162,10 @@ void SD_OPL2LPT_Startup(void)
 	for (int i = 0; i < allPorts.portc; ++i)
 	{
 		CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Found parallel port \"%s\"\n", allPorts.portv[i]->name);
+
+		// If this isn't the port we're looking for, look at the next one.
+		if (portName[0] && strcmp(portName, allPorts.portv[i]->name))
+			continue;
 		int caps = CAP1284_RAW;
 		sd_parport = allPorts.portv[i];
 		if (ieee1284_open(sd_parport, F1284_EXCL, &caps) != E1284_OK)

--- a/src/id_sd_sdl.c
+++ b/src/id_sd_sdl.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "id_cfg.h"
 #include "id_sd.h"
 #include "id_us.h"
 #include "ck_cross.h"
@@ -342,7 +343,19 @@ void SD_SDL_PCSpkOn(bool on, int freq)
 
 void SD_SDL_Startup(void)
 {
-	sd_oplEmulator = SD_OPL_EMULATOR_DBOPL;
+	const char *oplEmuString = CFG_GetConfigString("oplEmulator", "dbopl");
+	if (!CK_Cross_strcasecmp(oplEmuString, "nukedopl3"))
+		sd_oplEmulator = SD_OPL_EMULATOR_NUKED;
+	else if (!CK_Cross_strcasecmp(oplEmuString, "dbopl"))
+		sd_oplEmulator = SD_OPL_EMULATOR_DBOPL;
+	else
+	{
+		CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Unknown OPL emulator \"%s\". Valid values are \"dbopl\" and \"nukedopl3\".\n", oplEmuString);
+		sd_oplEmulator = SD_OPL_EMULATOR_DBOPL;
+	}
+
+	SD_SDL_useTimerFallback = CFG_GetConfigInt("sd_sdl_noAudioSync", 0);
+
 	for (int i = 0; i < us_argc; ++i)
 	{
 		if (!CK_Cross_strcasecmp(us_argv[i], "/NOAUDIOSYNC"))

--- a/src/id_str.c
+++ b/src/id_str.c
@@ -92,6 +92,25 @@ bool STR_AddEntry(STR_Table *tabl, const char *str, void *value)
 	return false;
 }
 
+// Iterate through the entires in the hashtable. "index" will be updated afterwards.
+void *STR_GetNextEntry(STR_Table *tabl, size_t *index)
+{
+	for (size_t i = *index;; i++)
+	{
+		if (i >= tabl->size)
+		{
+			// We're done.
+			*index = 0;
+			return (void *)0;
+		}
+		if (tabl->arr[i].str != 0)
+		{
+			*index = i + 1;
+			return (tabl->arr[i].ptr);
+		}
+	}
+}
+
 static char STR_PeekCharacter(STR_ParserState *ps)
 {
 	if (ps->dataindex >= ps->datasize)
@@ -142,6 +161,7 @@ STR_Token STR_GetToken(STR_ParserState *ps)
 	STR_SkipWhitespace(ps);
 	STR_Token tok;
 	tok.tokenType = STR_TOK_EOF;
+	tok.firstIndex = ps->dataindex;
 	if (STR_PeekCharacter(ps) && STR_PeekCharacter(ps) == '"')
 	{
 		// This is a string.
@@ -173,6 +193,7 @@ STR_Token STR_GetToken(STR_ParserState *ps)
 		while (STR_PeekCharacter(ps) && !isspace(STR_PeekCharacter(ps)))
 			tokenbuf[i++] = STR_GetCharacter(ps);
 	}
+	tok.lastIndex = ps->dataindex;
 	tokenbuf[i] = '\0';
 
 	// Copy the token into the temp Arena

--- a/src/id_str.h
+++ b/src/id_str.h
@@ -44,8 +44,7 @@ void *STR_LookupEntryWithDefault(STR_Table *tabl, const char *str, void *def);
 void *STR_LookupEntry(STR_Table *tabl, const char *str);
 bool STR_AddEntry(STR_Table *tabl, const char *str, void *value);
 
-
-
+void *STR_GetNextEntry(STR_Table *tabl, size_t *index);
 
 #define ID_STR_MAX_TOKEN_LENGTH 64
 
@@ -62,6 +61,12 @@ typedef struct STR_Token
 	STR_TokenType tokenType;
 	const char *valuePtr;
 	int valueLength;
+
+	// These are the first byte index in the input of the token, and the
+	// last byte index, respectively. These are used for saving modified
+	// files out.
+	int firstIndex;
+	int lastIndex;
 } STR_Token;
 
 typedef struct STR_ParserState


### PR DESCRIPTION
This set of changes finally adds a new config file: OMNISPK.CFG.

It's shared between episodes, and is currently used to save the new graphics options in the ComputerWrist (fullscreen, overscan border, etc). Modifying these settings in the menu will result in the config file being updated when the game quits.

The file itself is a basic key/value affair, and looks something like this:
```
# Graphics settings (these are integer/boolean values: 0 or 1).
fullscreen = 1
border = 1
integer = 0
aspect = 1

# Sound options

# The audio backend:
# Valid values: "alsa", "opl2lpt", "sdl"/"default".
sd_backend = "opl2lpt"
# The OPL emulator used by the SDL audio backend
# Valid values: "dbopl" (DOSBox), "nukedopl3" (NukedOPL3)
oplEmulator = "nukedopl3"
# We want the game timer synced to the soundcard (this is the default)
sd_sdl_noAudioSync 0
# ALSA device for hardware OPL2/3 support
sd_alsa_device = "hw0,0"
# Parallel port for OPL2LPT
sd_opl2lpt_port = "parport0"

# Disable the Keen6 copy protection
ck6_noCreatureQuestion = 1
```

There are still some issues with this: because it uses ID_FS for filesystem access (the config file, `OMNISPK.CFG` is stored in the User directory), the filsystem paths can't be configured from this file. Similarly, the new input options were already being stored in the CONFIG.CKx file. 

It may be confusing that some settings are per-episode (the old CONFIG.CKx ones), and some are global (these new ones). Possibly something to make configurable itself (at least at compile time?). Exactly what triggers these to be saved (and where to document them) is also worth asking.

Finally, I'm thinking about replacing some of the command-line options with these outright: for the more obscure ones, this seems a better place for them.