### PR TITLE
Make it possible to QuickLoad, QuickSave, and access the Status screen from the joystick

### DIFF
--- a/src/ck_game.c
+++ b/src/ck_game.c
@@ -839,7 +839,7 @@ bool CK_TryAgainMenu()
 			}
 
 #ifdef QUICKSAVE_ENABLED
-			if (IN_GetLastScan() == in_kbdControls.quickLoad)
+			if (IN_GetLastScan() == in_kbdControls.quickLoad || IN_IsJoyButtonDown(IN_joy_quickload))
 			{
 				// quickload, but fall back to map screen on failure
 				ck_gameState.currentLevel = 0;

--- a/src/ck_play.c
+++ b/src/ck_play.c
@@ -1064,9 +1064,9 @@ void CK_CheckKeys()
 
 	// Drop down status
 #ifdef EXTRA_KEYBOARD_OPTIONS
-	if (IN_GetKeyState(in_kbdControls.status))
+	if (IN_GetKeyState(in_kbdControls.status) || IN_IsJoyButtonDown(IN_joy_status))
 #else
-	if (IN_GetKeyState(IN_SC_Enter))
+	if (IN_GetKeyState(IN_SC_Enter) || IN_IsJoyButtonDown(IN_joy_status))
 #endif
 	{
 		CK_ShowStatusWindow();
@@ -1108,7 +1108,7 @@ void CK_CheckKeys()
 
 #ifdef QUICKSAVE_ENABLED
 		// Quicksave
-		if (IN_GetLastScan() == in_kbdControls.quickSave)
+		if (IN_GetLastScan() == in_kbdControls.quickSave || IN_IsJoyButtonDown(IN_joy_quicksave))
 		{
 			if (US_QuickSave())
 			{
@@ -1118,7 +1118,7 @@ void CK_CheckKeys()
 		}
 
 		// Quickload
-		else if (IN_GetLastScan() == in_kbdControls.quickLoad)
+		else if (IN_GetLastScan() == in_kbdControls.quickLoad || IN_IsJoyButtonDown(IN_joy_quickload))
 		{
 			if (US_QuickLoad())
 			{

--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -573,6 +573,11 @@ US_CardItem ck_us_joyconfMenuItems[] = {
 	{US_ITEM_Normal, 0, IN_SC_P, "POGO", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_F, "FIRE", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Normal, 0, IN_SC_M, "MENU", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Normal, 0, IN_SC_S, "STATUS", US_Comm_None, 0, 0, 0},
+#ifdef QUICKSAVE_ENABLED
+	{US_ITEM_Normal, 0, IN_SC_L, "QUICKLOAD", US_Comm_None, 0, 0, 0},
+	{US_ITEM_Normal, 0, IN_SC_Q, "QUICKSAVE", US_Comm_None, 0, 0, 0},
+#endif
 	{US_ITEM_Normal, 0, IN_SC_D, "DEAD ZONE", US_Comm_None, 0, 0, 0},
 	{US_ITEM_Submenu, 0, IN_SC_J, "", US_Comm_None, &ck_us_joyMotionModeMenu, 0, 0},
 	{US_ITEM_None, 0, IN_SC_None, 0, US_Comm_None, 0, 0, 0}};

--- a/src/id_cfg.c
+++ b/src/id_cfg.c
@@ -52,6 +52,20 @@ bool CFG_GetConfigBool(const char *name, bool defValue)
 	return CFG_GetConfigInt(name, defValue ? 1 : 0);
 }
 
+int CFG_GetConfigEnum(const char *name, const char **strings, int defValue)
+{
+	const char *valueStr = CFG_GetConfigString(name, NULL);
+	if (!valueStr)
+		return defValue;
+	
+	for (int i = 0; strings[i]; ++i)
+	{
+		if (!CK_Cross_strcasecmp(strings[i], valueStr))
+			return i;
+	}
+	return defValue;
+}
+
 // Gets or creates a config variable. When created, the name is StrDup'ed into the
 // config arena.
 static CFG_Variable *CFG_GetOrCreateVariable(const char *name)
@@ -97,6 +111,11 @@ void CFG_SetConfigBool(const char *name, bool value)
 	var->str_value = 0;
 	var->int_value = value ? 1 : 0;
 	var->is_boolean = true;
+}
+
+void CFG_SetConfigEnum(const char *name, const char **strings, int value)
+{
+	CFG_SetConfigString(name, strings[value]);
 }
 
 static bool CFG_ParseConfigLine(STR_ParserState *state)

--- a/src/id_cfg.h
+++ b/src/id_cfg.h
@@ -42,10 +42,12 @@ bool CFG_ConfigExists(const char *name);
 int CFG_GetConfigInt(const char *name, int defValue);
 const char *CFG_GetConfigString(const char *name, const char *defValue);
 bool CFG_GetConfigBool(const char *name, bool defValue);
+int CFG_GetConfigEnum(const char *name, const char **strings, int defValue);
 
 void CFG_SetConfigInt(const char *name, int value);
 void CFG_SetConfigString(const char *name, const char *value);
 void CFG_SetConfigBool(const char *name, bool value);
+void CFG_SetConfigEnum(const char *name, const char **strings, int value);
 
 void CFG_Startup();
 void CFG_Shutdown();

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -121,6 +121,14 @@ IN_Backend *in_backend = 0;
 
 #define IN_MAX_JOYSTICKS 2
 
+const char *IN_ControlType_Strings[] = {
+	"Keyboard1",
+	"Keyboard2",
+	"Joystick1",
+	"Joystick2",
+	"Mouse"
+};
+
 IN_KeyMapping in_kbdControls;
 
 // In Omnispeak, which doesn't support the classic Gravis Gamepad anyway,
@@ -500,6 +508,12 @@ uint16_t IN_GetJoyButtonsDB(int joystick)
 void IN_SetControlType(int player, IN_ControlType type)
 {
 	in_controlType = type;
+	
+	// Save the control type if we need to
+	if (CFG_GetConfigEnum("in_controlType", IN_ControlType_Strings, -1) != -1)
+	{
+		CFG_SetConfigEnum("in_controlType", IN_ControlType_Strings, in_controlType);
+	}
 }
 
 void In_GetJoyMotion(int joystick, IN_Motion *p_x, IN_Motion *p_y)

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -17,6 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include "id_cfg.h"
 #include "id_in.h"
 #include "id_mm.h"
 #include "id_sd.h"
@@ -809,40 +810,29 @@ bool IN_UserInput(int tics, bool waitPress)
 	return false;
 }
 
+// Must be in-sync with IN_JoyConfItem
+const char *IN_JoyConfNames[] = {
+	"in_joy_jump",
+	"in_joy_pogo",
+	"in_joy_fire",
+	"in_joy_menu",
+	"in_joy_deadzone",
+	"in_joy_modern"
+};
+
 int IN_GetJoyConf(IN_JoyConfItem item)
 {
-	switch (item)
-	{
-		case IN_joy_deadzone:
-			return in_joyDeadzonePercent;
-		case IN_joy_modern:
-			return in_joyAdvancedMotion ? 1 : 0;
-		default:
-			return ((item >= IN_joy_button_min_) && (item <= IN_joy_button_max_))
-				? in_gamepadButtons[(int)item]
-				: 0;
-	}
+	return CFG_GetConfigInt(IN_JoyConfNames[item], 0);
 }
 
 void IN_SetJoyConf(IN_JoyConfItem item, int value)
 {
-	switch (item)
-	{
-		case IN_joy_deadzone:
-			in_joyDeadzonePercent = (int16_t)value;
-			break;
-		case IN_joy_modern:
-			in_joyAdvancedMotion = (value != 0);
-			break;
-		default:
-			if ((item >= IN_joy_button_min_) && (item <= IN_joy_button_max_))
-				in_gamepadButtons[(int)item] = (int16_t)value;
-	}
+	CFG_SetConfigInt(IN_JoyConfNames[item], value);
 }
 
 bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn)
 {
-	int btn_id = in_gamepadButtons[(int)btn];
+	int btn_id = IN_GetJoyConf(btn);
 	return (btn_id < 0) ? 0 : ((mask >> btn_id) & 1);
 }
 

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -816,6 +816,9 @@ const char *IN_JoyConfNames[] = {
 	"in_joy_pogo",
 	"in_joy_fire",
 	"in_joy_menu",
+	"in_joy_status",
+	"in_joy_quickload",
+	"in_joy_quicksave",
 	"in_joy_deadzone",
 	"in_joy_modern"
 };
@@ -834,6 +837,14 @@ bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn)
 {
 	int btn_id = IN_GetJoyConf(btn);
 	return (btn_id < 0) ? 0 : ((mask >> btn_id) & 1);
+}
+
+bool IN_IsJoyButtonDown(IN_JoyConfItem btn)
+{
+	int joy = in_controlType - IN_ctrl_Joystick1;
+	if (joy < 0 || joy >= IN_MAX_JOYSTICKS) return false;
+	uint16_t mask = IN_GetJoyButtonsDB(joy);
+	return IN_GetJoyButtonFromMask(mask, btn);
 }
 
 const char *IN_GetJoyName(int joystick)

--- a/src/id_in.c
+++ b/src/id_in.c
@@ -839,7 +839,7 @@ const char *IN_JoyConfNames[] = {
 
 int IN_GetJoyConf(IN_JoyConfItem item)
 {
-	return CFG_GetConfigInt(IN_JoyConfNames[item], 0);
+	return CFG_GetConfigInt(IN_JoyConfNames[item], item);
 }
 
 void IN_SetJoyConf(IN_JoyConfItem item, int value)

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -233,6 +233,8 @@ typedef enum IN_ControlType
 	IN_ctrl_Mouse
 } IN_ControlType;
 
+extern const char *IN_ControlType_Strings[];
+
 typedef struct IN_ControlFrame
 {
 	bool jump, pogo, button2, button3;

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -263,10 +263,8 @@ typedef enum IN_JoyConfItem
 	IN_joy_pogo = 1,
 	IN_joy_fire = 2,
 	IN_joy_menu = 3,
-	IN_joy_deadzone = 4,	// not saved in CONFIG.CKx
-	IN_joy_modern = 5,	// not saved in CONFIG.CKx
-	IN_joy_button_min_ = IN_joy_jump,
-	IN_joy_button_max_ = IN_joy_menu,
+	IN_joy_deadzone = 4,
+	IN_joy_modern = 5
 } IN_JoyConfItem;
 
 void IN_PumpEvents();

--- a/src/id_in.h
+++ b/src/id_in.h
@@ -259,12 +259,17 @@ extern bool in_joyAdvancedMotion;
 
 typedef enum IN_JoyConfItem
 {
-	IN_joy_jump = 0,
-	IN_joy_pogo = 1,
-	IN_joy_fire = 2,
-	IN_joy_menu = 3,
-	IN_joy_deadzone = 4,
-	IN_joy_modern = 5
+	IN_joy_jump,
+	IN_joy_pogo,
+	IN_joy_fire,
+	IN_joy_menu,
+	IN_joy_status,
+#ifdef QUICKSAVE_ENABLED
+	IN_joy_quickload,
+	IN_joy_quicksave,
+#endif
+	IN_joy_deadzone,
+	IN_joy_modern
 } IN_JoyConfItem;
 
 void IN_PumpEvents();
@@ -299,6 +304,7 @@ bool IN_UserInput(int tics, bool arg4);
 int IN_GetJoyConf(IN_JoyConfItem item);
 void IN_SetJoyConf(IN_JoyConfItem item, int value);
 bool IN_GetJoyButtonFromMask(uint16_t mask, IN_JoyConfItem btn);
+bool IN_IsJoyButtonDown(IN_JoyConfItem btn);
 const char *IN_GetJoyName(int joystick);
 
 // Called by the backend.

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -748,7 +748,10 @@ void US_LoadConfig(void)
 	}
 	SD_SetQuietSfx(hadQuietSfx);
 	SD_Default(configFileLoaded && (hadAdlib == SD_IsAdlibPresent()), sd, sm);
-	IN_Default(configFileLoaded, inputDevice);
+	if (CFG_GetConfigInt("in_controlType", -1) != -1)
+		IN_Default(true, CFG_GetConfigInt("in_controlType", -1));
+	else
+		IN_Default(configFileLoaded, inputDevice);
 }
 
 void US_SaveConfig(void)
@@ -777,6 +780,10 @@ void US_SaveConfig(void)
 	FS_WriteInt16LE(&intVal, 1, f);
 
 	// FIXME: Currently it is unused
+	if (CFG_GetConfigInt("in_controlType", -1) != -1)
+	{
+		CFG_SetConfigInt("in_controlType", in_controlType);
+	}
 	intVal = (int16_t)in_controlType;
 	FS_WriteInt16LE(&intVal, 1, f); // Input device
 

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -748,10 +748,7 @@ void US_LoadConfig(void)
 	}
 	SD_SetQuietSfx(hadQuietSfx);
 	SD_Default(configFileLoaded && (hadAdlib == SD_IsAdlibPresent()), sd, sm);
-	if (CFG_GetConfigInt("in_controlType", -1) != -1)
-		IN_Default(true, CFG_GetConfigInt("in_controlType", -1));
-	else
-		IN_Default(configFileLoaded, inputDevice);
+	IN_Default(configFileLoaded, inputDevice);
 }
 
 void US_SaveConfig(void)
@@ -779,11 +776,6 @@ void US_SaveConfig(void)
 	intVal = (int16_t)SD_GetMusicMode();
 	FS_WriteInt16LE(&intVal, 1, f);
 
-	// FIXME: Currently it is unused
-	if (CFG_GetConfigInt("in_controlType", -1) != -1)
-	{
-		CFG_SetConfigInt("in_controlType", in_controlType);
-	}
 	intVal = (int16_t)in_controlType;
 	FS_WriteInt16LE(&intVal, 1, f); // Input device
 


### PR DESCRIPTION
Will fix issue #35.

I'm still not convinced this is exactly how I want to implement this — it's definitely a breaking change, config wise, and I feel that there might be more sense in having a more generic "bindable action" framework and then plugging this through it. (Things like quitting to menu probably shouldn't be in the control struct, as they're not "in-game", for instance.)

There's also the possibility of using SDL_GameController to setup a nicer default config — at the moment, this is defaulting to all button 0, which is clearly not right.