### PR TITLE
FileIO: Make file typedef consistent

### DIFF
--- a/src/ck_def.h
+++ b/src/ck_def.h
@@ -452,8 +452,8 @@ void CK_SubmitHighScore(int score, uint16_t arg4);
 void CK_DoHighScores();
 
 /* ck_game.c */
-bool CK_SaveGame(FILE *fp);
-bool CK_LoadGame(FILE *fp, bool fromMenu);
+bool CK_SaveGame(FS_File fp);
+bool CK_LoadGame(FS_File fp, bool fromMenu);
 
 /* ck_keen.c */
 extern soundnames *ck_itemSounds;

--- a/src/ck_game.c
+++ b/src/ck_game.c
@@ -87,7 +87,7 @@ void CK_GameOver()
 }
 
 // OMNISPEAK - New cross-platform methods for reading/writing objects from/to saved games
-bool CK_SaveObject(FILE *fp, CK_object *o)
+bool CK_SaveObject(FS_File fp, CK_object *o)
 {
 	int16_t dummy = 0;
 	// Convert a few enums
@@ -158,7 +158,7 @@ bool CK_SaveObject(FILE *fp, CK_object *o)
 	// clang-format on
 }
 
-static bool CK_LoadObject(FILE *fp, CK_object *o)
+static bool CK_LoadObject(FS_File fp, CK_object *o)
 {
 	int16_t dummy;
 	// Convert a few enums
@@ -224,7 +224,7 @@ static bool CK_LoadObject(FILE *fp, CK_object *o)
 }
 
 // Similar new methods for writing/reading game state
-bool CK_SaveGameState(FILE *fp, CK_GameState *state)
+bool CK_SaveGameState(FS_File fp, CK_GameState *state)
 {
 	int16_t difficultyInt = (int16_t)state->difficulty; // Convert enum
 	// TODO - platform should be a part of the game state
@@ -263,7 +263,7 @@ bool CK_SaveGameState(FILE *fp, CK_GameState *state)
 	// clang-format on
 }
 
-static bool CK_LoadGameState(FILE *fp, CK_GameState *state)
+static bool CK_LoadGameState(FS_File fp, CK_GameState *state)
 {
 	int16_t difficultyInt; // Convert num
 	uint16_t platformObjOffset;
@@ -311,7 +311,7 @@ static bool CK_LoadGameState(FILE *fp, CK_GameState *state)
 	return true;
 }
 
-bool CK_SaveGame(FILE *fp)
+bool CK_SaveGame(FS_File fp)
 {
 	int i;
 	uint16_t cmplen, bufsize;
@@ -360,7 +360,7 @@ bool CK_SaveGame(FILE *fp)
 	return true;
 }
 
-bool CK_LoadGame(FILE *fp, bool fromMenu)
+bool CK_LoadGame(FS_File fp, bool fromMenu)
 {
 	int i;
 	uint16_t cmplen, bufsize;

--- a/src/ck_play.c
+++ b/src/ck_play.c
@@ -2200,8 +2200,8 @@ void CK_PlayLoop()
 #ifdef CK_ENABLE_PLAYLOOP_DUMPER
 		if (ck_dumperFile)
 		{
-			bool CK_SaveObject(FILE * fp, CK_object * o);
-			bool CK_SaveGameState(FILE * fp, CK_GameState * state);
+			bool CK_SaveObject(FS_File fp, CK_object * o);
+			bool CK_SaveGameState(FS_File fp, CK_GameState * state);
 
 			uint32_t timecountToDump = SD_GetTimeCount();
 			FS_WriteInt32LE(&timecountToDump, 1, ck_dumperFile);

--- a/src/ck_us_2.c
+++ b/src/ck_us_2.c
@@ -367,14 +367,14 @@ extern const char *footer_str[3];
 static bool US_SaveMain(int i)
 {
 	int n, error = 0;
-	FILE *fp;
+	FS_File fp;
 	const char *fname;
 	US_Savefile *e;
 
 	e = &us_savefiles[i];
 	fname = US_GetSavefileName(i);
 	fp = FS_CreateUserFile(fname);
-	if (fp != NULL)
+	if (FS_IsFileValid(fp))
 	{
 		// Omnispeak - writing US_Savefile fields one-by-one
 		// for cross-platform support

--- a/src/id_ca.c
+++ b/src/id_ca.c
@@ -179,7 +179,7 @@ bool CA_LoadFile(const char *filename, mm_ptr_t *ptr, int *memsize)
 
 	int amountRead = FS_Read(*ptr, 1, length, f);
 
-	fclose(f);
+	FS_CloseFile(f);
 
 	if (amountRead != length)
 		return false;
@@ -905,7 +905,7 @@ void CAL_SetupMapFile(void)
 
 static ca_huffnode *ca_audiohuffman;
 
-static FILE *ca_audiohandle; //File Pointer for AUDIO file.
+static FS_File ca_audiohandle; //File Pointer for AUDIO file.
 int32_t *ca_audiostarts;
 
 void CAL_SetupAudioFile(void)

--- a/src/id_us.h
+++ b/src/id_us.h
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "ck_cross.h"
 
 #include "id_in.h"
+#include "id_fs.h"
 
 /* This keeps clang's static analyzer quiet. */
 #ifdef __GNUC__
@@ -184,11 +185,11 @@ bool US_QuickLoad();
 int USL_CtlDialog(const char *s1, const char *s2, const char *s3);
 
 // A few function pointers
-extern bool (*p_save_game)(FILE *handle);
-extern bool (*p_load_game)(FILE *handle, bool fromMenu);
+extern bool (*p_save_game)(FS_File handle);
+extern bool (*p_load_game)(FS_File handle, bool fromMenu);
 extern void (*p_exit_menu)(void);
 
-void US_SetMenuFunctionPointers(bool (*loadgamefunc)(FILE *, bool), bool (*savegamefunc)(FILE *), void (*exitmenufunc)(void));
+void US_SetMenuFunctionPointers(bool (*loadgamefunc)(FS_File, bool), bool (*savegamefunc)(FS_File), void (*exitmenufunc)(void));
 
 
 typedef void (*US_MeasureStringFunc)(const char *string, uint16_t *width, uint16_t *height, int16_t chunk);

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -76,8 +76,8 @@ static int8_t us_printColour = 15;
 #define US_WINDOW_MAX_X 320
 #define US_WINDOW_MAX_Y 200
 
-bool (*p_save_game)(FILE *handle);
-bool (*p_load_game)(FILE *handle, bool fromMenu);
+bool (*p_save_game)(FS_File handle);
+bool (*p_load_game)(FS_File handle, bool fromMenu);
 void (*p_exit_menu)(void);
 
 US_MeasureStringFunc USL_MeasureString = VH_MeasurePropString;
@@ -89,7 +89,7 @@ void US_SetPrintRoutines(US_MeasureStringFunc measure, US_DrawStringFunc draw)
 	USL_DrawString = (draw) ? draw : VHB_DrawPropString;
 }
 
-void US_SetMenuFunctionPointers(bool (*loadgamefunc)(FILE *, bool), bool (*savegamefunc)(FILE *), void (*exitmenufunc)(void))
+void US_SetMenuFunctionPointers(bool (*loadgamefunc)(FS_File, bool), bool (*savegamefunc)(FS_File), void (*exitmenufunc)(void))
 {
 	p_load_game = loadgamefunc;
 	p_save_game = savegamefunc;
@@ -682,7 +682,7 @@ void US_LoadConfig(void)
 		if (strcmp(fileExt, ck_currentEpisode->ext) || (configRev != 4))
 		{
 			FS_CloseFile(f);
-			f = NULL;
+			f = 0;
 		}
 	}
 	if (FS_IsFileValid(f))
@@ -847,7 +847,7 @@ void US_GetSavefiles(void)
 			// Omnispeak - reading US_Savefile fields one-by-one
 			// for cross-platform support
 			uint8_t padding; // One byte of struct padding
-			if ((fread(psfe->id, sizeof(psfe->id), 1, handle) == 1) &&
+			if ((FS_Read(psfe->id, sizeof(psfe->id), 1, handle) == 1) &&
 				(FS_ReadInt16LE(&psfe->printXOffset, 1, handle) == 1) &&
 				(FS_ReadBoolFrom16LE(&psfe->used, 1, handle) == 1) &&
 				(FS_Read(psfe->name, sizeof(psfe->name), 1, handle) == 1) &&


### PR DESCRIPTION
The file system uses the wrapper FS_File to increase portability. This PR applies the wrapper across the rest of the code base as it is missed in a few places.

Tested on Windows MINGW build, episode 4 5 and 6.

Maybe a future iteration could make the file IO a backend driver similar to how audio,,video and sound is handled :)
