### PR TITLE
Initial SDL3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,37 @@ elseif(RENDERER STREQUAL "sdl3")
 		${SDL3_INCLUDE_DIRS}
 	)
 	add_definitions(-DWITH_SDL=3)
+elseif(RENDERER STREQUAL "sdl3gpu")
+	message(STATUS "Using SDL3 gpu backend")
+	find_package(SDL3 REQUIRED)
+	add_custom_command(OUTPUT id_vl_vk_vert.h
+		COMMAND glslc -mfmt=c
+			${CMAKE_CURRENT_SOURCE_DIR}/src/id_vl_vk_shader.vert
+			-o id_vl_vk_vert.h
+		DEPENDS src/id_vl_vk_shader.vert
+	)
+
+	add_custom_command(OUTPUT id_vl_vk_frag.h
+		COMMAND glslc -mfmt=c
+			${CMAKE_CURRENT_SOURCE_DIR}/src/id_vl_vk_shader.frag
+			-o id_vl_vk_frag.h
+		DEPENDS src/id_vl_vk_shader.frag
+	)
+	set(OMNISPEAK_PLATFORM_SRCS
+		src/id_in_sdl3.c
+		src/id_sd_sdl3.c
+		src/id_vl_sdl3gpu.c
+		${CMAKE_CURRENT_BINARY_DIR}/id_vl_vk_vert.h
+		${CMAKE_CURRENT_BINARY_DIR}/id_vl_vk_frag.h
+	)
+	set(OMNISPEAK_PLATFORM_LIBRARIES
+		${SDL3_LIBRARIES}
+	)
+	include_directories(
+		${SDL3_INCLUDE_DIRS}
+		${CMAKE_CURRENT_BINARY_DIR}
+	)
+	add_definitions(-DWITH_SDL=3)
 else()
 	message(WARNING "Using NULL platform layer.")
 	set(OMNISPEAK_PLATFORM_SRCS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,21 @@ elseif(RENDERER STREQUAL "sdl1")
 		${SDL_INCLUDE_DIR}
 	)
 	add_definitions(-DWITH_SDL)
+elseif(RENDERER STREQUAL "sdl3")
+	message(STATUS "Using SDL3 renderer backend")
+	find_package(SDL3 REQUIRED)
+	set(OMNISPEAK_PLATFORM_SRCS
+		src/id_in_sdl3.c
+		src/id_sd_sdl3.c
+		src/id_vl_sdl3.c
+	)
+	set(OMNISPEAK_PLATFORM_LIBRARIES
+		${SDL3_LIBRARIES}
+	)
+	include_directories(
+		${SDL3_INCLUDE_DIRS}
+	)
+	add_definitions(-DWITH_SDL=3)
 else()
 	message(WARNING "Using NULL platform layer.")
 	set(OMNISPEAK_PLATFORM_SRCS

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,7 @@ This Makefile supports the following options:
 		  sdl2gl  = SDL 2.0 + OpenGL 2.0 (default)
 		  sdl2vk  = SDL 2.0 + Vulkan (experimental)
 		  sdl3    = SDL 3.0 + SDL_Renderer
+		  sdl3gpu = SDL 3.0 GPU
 		  null    = dummy renderer
 
   WITH_KEEN4    whether to include support for Keen 4: Secret of the Oracle (0/1; default: on)
@@ -374,6 +375,13 @@ ifeq ($(RENDERER), sdl3)
 	SDL_LIBS = `$(BINPREFIX)pkg-config sdl3 $(SDL_PKG_CONFIG_PREFIX) $(SDL_LIB_QUERY)`
 endif
 
+ifeq ($(RENDERER), sdl3gpu)
+	RENDER_OBJS = id_vl_sdl3gpu.o id_sd_sdl3.o id_in_sdl3.o
+	SDL_CFLAGS = `$(BINPREFIX)pkg-config sdl3 $(SDL_PKG_CONFIG_PREFIX) --cflags` -DWITH_SDL=3
+	SDL_LIBS = `$(BINPREFIX)pkg-config sdl3 $(SDL_PKG_CONFIG_PREFIX) $(SDL_LIB_QUERY)`
+	CXXFLAGS += -I$(OBJDIR) #For generated SPIR-V headers
+endif
+
 ifeq ($(RENDERER), dos)
 	RENDER_OBJS = id_vl_dos.o id_sd_dos.o id_in_dos.o
 	CXXFLAGS += -DVL_EGA=1
@@ -485,6 +493,7 @@ $(BINDIR):
 	mkdir -p $(BINDIR)
 
 $(OBJDIR)/id_vl_sdl2vk.o: $(OBJDIR)/id_vl_vk_frag.h $(OBJDIR)/id_vl_vk_vert.h
+$(OBJDIR)/id_vl_sdl3gpu.o: $(OBJDIR)/id_vl_vk_frag.h $(OBJDIR)/id_vl_vk_vert.h
 
 $(OBJDIR)/id_vl_vk_%.h: id_vl_vk_shader.%
 	@mkdir -p $(dir $@)

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,6 +33,7 @@ This Makefile supports the following options:
 		  sdl2sw  = SDL 2.0 + Software SDL_Renderer
 		  sdl2gl  = SDL 2.0 + OpenGL 2.0 (default)
 		  sdl2vk  = SDL 2.0 + Vulkan (experimental)
+		  sdl3    = SDL 3.0 + SDL_Renderer
 		  null    = dummy renderer
 
   WITH_KEEN4    whether to include support for Keen 4: Secret of the Oracle (0/1; default: on)
@@ -83,6 +84,7 @@ This Makefile supports the following options:
 
   SDL1_VERSION  version of SDL 1.x to download and use (if LOCAL_SDL=1)
   SDL2_VERSION  version of SDL 2.x to download and use (if LOCAL_SDL=1)
+  SDL3_VERSION  version of SDL 3.x to download and use (if LOCAL_SDL=1)
 
   COMPILER	explicit path of the compiler (overrides CLANG option)
   CXXFLAGS      additional options for the compiler
@@ -117,7 +119,11 @@ endif
 ifneq (,$(findstring win,$(PLATFORM)))
 	# common Windows stuff
 	EXE_EXT = .exe
-	DEFAULT_STATIC = 1
+	# SDL3 no longer provides static binaries for mingw, so don't make it the default
+	# https://github.com/libsdl-org/SDL/issues/11132
+	ifeq (,$(findstring sdl3,$(RENDERER)))
+		DEFAULT_STATIC = 1
+	endif
 	DEFAULT_LOCAL_SDL = 1
 	DEFAULT_RENDERER = sdl2
 	LIBGL = -lopengl32
@@ -184,6 +190,7 @@ KEEN6VER ?= keen6e15
 XDGUSERPATH ?= 0
 SDL1_VERSION ?= 1.2.15
 SDL2_VERSION ?= 2.30.9
+SDL3_VERSION ?= 3.2.0
 SYSFLAGS ?=
 CXX ?=
 CXXFLAGS ?=
@@ -263,7 +270,11 @@ endif
 # set linker flags for static linking
 ifeq ($(STATIC), 1)
 	LDFLAGS += -static
-	SDL_LIB_QUERY = --static-libs
+	ifneq (,$(findstring sdl3,$(RENDERER)))
+		SDL_LIB_QUERY = --static --libs
+	else
+		SDL_LIB_QUERY = --static-libs
+	endif
 else
 	SDL_LIB_QUERY = --libs
 endif
@@ -274,11 +285,15 @@ ifeq ($(RENDERER), sdl1)
 	SDL_VERSION = $(SDL1_VERSION)
 	SDL_URL = http://libsdl.org/release/SDL-devel-$(SDL_VERSION)-mingw32.tar.gz
 	SDL_LOCAL_PREFIX = SDL-$(SDL_VERSION)
-else
+else ifneq (,$(findstring sdl2,$(RENDERER)))
 	SDL_CONFIG_BIN = $(SDL_CONFIG_PREFIX)sdl2-config
 	SDL_VERSION = $(SDL2_VERSION)
 	SDL_URL = http://libsdl.org/release/SDL2-devel-$(SDL_VERSION)-mingw.tar.gz
 	SDL_LOCAL_PREFIX = SDL2-$(SDL_VERSION)/$(TOOLSET)
+else
+	SDL_VERSION = $(SDL3_VERSION)
+	SDL_URL = https://www.libsdl.org/release/SDL3-devel-$(SDL_VERSION)-mingw.tar.gz
+	SDL_LOCAL_PREFIX = SDL3-$(SDL_VERSION)/$(TOOLSET)
 endif
 
 # set SDL specific parameters
@@ -286,6 +301,7 @@ ifneq (,$(findstring sdl,$(RENDERER)))
 	ifeq ($(LOCAL_SDL),1)
 		SDL_DIR = ../$(SDL_LOCAL_PREFIX)
 		SDL_CONFIG = $(SDL_DIR)/bin/$(SDL_CONFIG_BIN) --prefix=$(SDL_DIR)
+		SDL_PKG_CONFIG_PREFIX = "--with-path=$(SDL_DIR)/lib/pkgconfig"
 	else
 		SDL_CONFIG = $(SDL_CONFIG_BIN)
 	endif
@@ -350,6 +366,12 @@ ifeq ($(RENDERER), sdl2vk)
 	RENDER_OBJS = id_vl_sdl2vk.o id_sd_sdl.o id_in_sdl.o
 	LIBS += $(LIBVULKAN)
 	CXXFLAGS += -I$(OBJDIR) #For generated SPIR-V headers
+endif
+
+ifeq ($(RENDERER), sdl3)
+	RENDER_OBJS = id_vl_sdl3.o id_sd_sdl3.o id_in_sdl3.o
+	SDL_CFLAGS = `$(BINPREFIX)pkg-config sdl3 $(SDL_PKG_CONFIG_PREFIX) --cflags` -DWITH_SDL=3
+	SDL_LIBS = `$(BINPREFIX)pkg-config sdl3 $(SDL_PKG_CONFIG_PREFIX) $(SDL_LIB_QUERY)`
 endif
 
 ifeq ($(RENDERER), dos)

--- a/src/ck_cross.h
+++ b/src/ck_cross.h
@@ -7,7 +7,11 @@
 #include <stdio.h>
 
 #ifdef WITH_SDL
+#if WITH_SDL == 3
+#include <SDL3/SDL.h>
+#else
 #include "SDL.h"
+#endif
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
 #define CK_CROSS_IS_BIGENDIAN
 #elif (SDL_BYTEORDER == SDL_LIL_ENDIAN)

--- a/src/ck_keen.c
+++ b/src/ck_keen.c
@@ -1339,7 +1339,7 @@ void CK_KeenPogoThink(CK_object *obj)
 {
 	if (!ck_keenState.jumpTimer)
 	{
-		if (ck_gameState.difficulty == D_Easy)
+		if (ck_gameState.difficulty == D_Easy && CK_INT(ck_easyJumpGravity, 1))
 		{
 			CK_PhysGravityMid(obj);
 		}

--- a/src/ck_main.c
+++ b/src/ck_main.c
@@ -43,9 +43,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef WITH_SDL
-#include <SDL.h> // For main (SDL_main) function prototype
-#endif
 /*
  * The 'episode' we're playing.
  */
@@ -115,7 +112,7 @@ void CK_InitGame()
 {
 	// On Windows, we want to be DPI-aware
 #if defined(WITH_SDL) && defined(_WIN32)
-#if SDL_VERSION_ATLEAST(2,24,0)
+#if SDL_VERSION_ATLEAST(2,24,0) && !SDL_VERSION_ATLEAST(3,0,0)
 	SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "1");
 #endif
 #endif

--- a/src/icon.c
+++ b/src/icon.c
@@ -1,13 +1,14 @@
 /* GIMP RGBA C-Source image dump (icon.c) */
 
 #ifdef WITH_SDL
-#include <SDL.h>
+// ck_cross.h includes the correct SDL header.
+#include "ck_cross.h"
 
 
 static const struct {
   unsigned int 	 width;
   unsigned int 	 height;
-  unsigned int 	 bytes_per_pixel; /* 2:RGB16, 3:RGB, 4:RGBA */ 
+  unsigned int 	 bytes_per_pixel; /* 2:RGB16, 3:RGB, 4:RGBA */
   unsigned char	 pixel_data[64 * 64 * 4 + 1];
 } sparky_icon = {
   64, 64, 4,
@@ -555,11 +556,18 @@ static const struct {
 
 void VL_SDL2GL_SetIcon(SDL_Window *wnd)
 {
+#if SDL_VERSION_ATLEAST(3,0,0)
+	SDL_Surface *iconSurf = SDL_CreateSurfaceFrom(sparky_icon.width, sparky_icon.height, SDL_PIXELFORMAT_ABGR8888, (void *)sparky_icon.pixel_data, sparky_icon.width*4);
+#else
 	SDL_Surface *iconSurf = SDL_CreateRGBSurfaceFrom((void*)sparky_icon.pixel_data, sparky_icon.width, sparky_icon.height, 32, sparky_icon.width*4, 0x000000FF, 0x0000FF00, 0x00FF0000,0xFF000000);
-
+#endif
 
 	SDL_SetWindowIcon(wnd, iconSurf);
+#if SDL_VERSION_ATLEAST(3,0,0)
+	SDL_DestroySurface(iconSurf);
+#else
 	SDL_FreeSurface(iconSurf);
+#endif
 }
 
 #endif

--- a/src/id_ca.c
+++ b/src/id_ca.c
@@ -34,9 +34,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <stdio.h>
 #include <string.h>
-#ifdef WITH_SDL
-#include "SDL.h"
-#endif
 
 #define CA_THREEBYTEHEADERS
 

--- a/src/id_in_sdl3.c
+++ b/src/id_in_sdl3.c
@@ -1,0 +1,391 @@
+/*
+Omnispeak: A Commander Keen Reimplementation
+Copyright (C) 2018 Omnispeak Authors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "id_in.h"
+#include "id_sd.h"
+#include "id_us.h"
+#include "id_vl.h"
+
+#include <SDL3/SDL.h>
+#include <string.h>
+
+extern SDL_Window *vl_sdl3_window;
+
+#define IN_MAX_JOYSTICKS 2
+
+SDL_Joystick *in_joysticks[IN_MAX_JOYSTICKS];
+SDL_Gamepad *in_controllers[IN_MAX_JOYSTICKS];
+bool in_joystickPresent[IN_MAX_JOYSTICKS];
+bool in_joystickHasHat[IN_MAX_JOYSTICKS];
+
+// SDLKey -> IN_SC
+#define INL_MapKey(sdl, in_sc) \
+	case sdl:              \
+		return in_sc
+
+static IN_ScanCode INL_SDLKeySymToScanCode(const SDL_KeyboardEvent *keySym)
+{
+	int sdlScanCode = keySym->scancode;
+	switch (sdlScanCode)
+	{
+		INL_MapKey(SDL_SCANCODE_RETURN, IN_SC_Enter);
+		INL_MapKey(SDL_SCANCODE_ESCAPE, IN_SC_Escape);
+		INL_MapKey(SDL_SCANCODE_SPACE, IN_SC_Space);
+		INL_MapKey(SDL_SCANCODE_BACKSPACE, IN_SC_Backspace);
+		INL_MapKey(SDL_SCANCODE_TAB, IN_SC_Tab);
+		INL_MapKey(SDL_SCANCODE_LALT, IN_SC_Alt);
+		INL_MapKey(SDL_SCANCODE_RALT, IN_SC_Alt);
+		INL_MapKey(SDL_SCANCODE_LCTRL, IN_SC_Control);
+		INL_MapKey(SDL_SCANCODE_RCTRL, IN_SC_Control);
+		INL_MapKey(SDL_SCANCODE_CAPSLOCK, IN_SC_CapsLock);
+		INL_MapKey(SDL_SCANCODE_NUMLOCKCLEAR, IN_SC_NumLock);
+		INL_MapKey(SDL_SCANCODE_SCROLLLOCK, IN_SC_ScrollLock);
+		INL_MapKey(SDL_SCANCODE_LSHIFT, IN_SC_LeftShift);
+		INL_MapKey(SDL_SCANCODE_RSHIFT, IN_SC_RightShift);
+		INL_MapKey(SDL_SCANCODE_UP, IN_SC_UpArrow);
+		INL_MapKey(SDL_SCANCODE_LEFT, IN_SC_LeftArrow);
+		INL_MapKey(SDL_SCANCODE_RIGHT, IN_SC_RightArrow);
+		INL_MapKey(SDL_SCANCODE_DOWN, IN_SC_DownArrow);
+		INL_MapKey(SDL_SCANCODE_INSERT, IN_SC_Insert);
+		INL_MapKey(SDL_SCANCODE_DELETE, IN_SC_Delete);
+		INL_MapKey(SDL_SCANCODE_HOME, IN_SC_Home);
+		INL_MapKey(SDL_SCANCODE_END, IN_SC_End);
+		INL_MapKey(SDL_SCANCODE_PAGEUP, IN_SC_PgUp);
+		INL_MapKey(SDL_SCANCODE_PAGEDOWN, IN_SC_PgDown);
+
+		INL_MapKey(SDL_SCANCODE_PAUSE, IN_SC_Pause);
+
+		INL_MapKey(SDL_SCANCODE_F1, IN_SC_F1);
+		INL_MapKey(SDL_SCANCODE_F2, IN_SC_F2);
+		INL_MapKey(SDL_SCANCODE_F3, IN_SC_F3);
+		INL_MapKey(SDL_SCANCODE_F4, IN_SC_F4);
+		INL_MapKey(SDL_SCANCODE_F5, IN_SC_F5);
+		INL_MapKey(SDL_SCANCODE_F6, IN_SC_F6);
+		INL_MapKey(SDL_SCANCODE_F7, IN_SC_F7);
+		INL_MapKey(SDL_SCANCODE_F8, IN_SC_F8);
+		INL_MapKey(SDL_SCANCODE_F9, IN_SC_F9);
+		INL_MapKey(SDL_SCANCODE_F10, IN_SC_F10);
+
+		INL_MapKey(SDL_SCANCODE_F11, IN_SC_F11);
+		INL_MapKey(SDL_SCANCODE_F12, IN_SC_F12);
+
+		INL_MapKey(SDL_SCANCODE_GRAVE, IN_SC_Grave);
+
+		INL_MapKey(SDL_SCANCODE_1, IN_SC_One);
+		INL_MapKey(SDL_SCANCODE_2, IN_SC_Two);
+		INL_MapKey(SDL_SCANCODE_3, IN_SC_Three);
+		INL_MapKey(SDL_SCANCODE_4, IN_SC_Four);
+		INL_MapKey(SDL_SCANCODE_5, IN_SC_Five);
+		INL_MapKey(SDL_SCANCODE_6, IN_SC_Six);
+		INL_MapKey(SDL_SCANCODE_7, IN_SC_Seven);
+		INL_MapKey(SDL_SCANCODE_8, IN_SC_Eight);
+		INL_MapKey(SDL_SCANCODE_9, IN_SC_Nine);
+		INL_MapKey(SDL_SCANCODE_0, IN_SC_Zero);
+
+		INL_MapKey(SDL_SCANCODE_MINUS, IN_SC_Minus);
+		INL_MapKey(SDL_SCANCODE_EQUALS, IN_SC_Equals);
+
+		INL_MapKey(SDL_SCANCODE_LEFTBRACKET, IN_SC_LeftBracket);
+		INL_MapKey(SDL_SCANCODE_RIGHTBRACKET, IN_SC_RightBracket);
+
+		INL_MapKey(SDL_SCANCODE_SEMICOLON, IN_SC_SemiColon);
+		INL_MapKey(SDL_SCANCODE_APOSTROPHE, IN_SC_SingleQuote);
+		INL_MapKey(SDL_SCANCODE_BACKSLASH, IN_SC_BackSlash);
+
+		INL_MapKey(SDL_SCANCODE_COMMA, IN_SC_Comma);
+		INL_MapKey(SDL_SCANCODE_PERIOD, IN_SC_Period);
+		INL_MapKey(SDL_SCANCODE_SLASH, IN_SC_Slash);
+
+		INL_MapKey(SDL_SCANCODE_A, IN_SC_A);
+		INL_MapKey(SDL_SCANCODE_B, IN_SC_B);
+		INL_MapKey(SDL_SCANCODE_C, IN_SC_C);
+		INL_MapKey(SDL_SCANCODE_D, IN_SC_D);
+		INL_MapKey(SDL_SCANCODE_E, IN_SC_E);
+		INL_MapKey(SDL_SCANCODE_F, IN_SC_F);
+		INL_MapKey(SDL_SCANCODE_G, IN_SC_G);
+		INL_MapKey(SDL_SCANCODE_H, IN_SC_H);
+		INL_MapKey(SDL_SCANCODE_I, IN_SC_I);
+		INL_MapKey(SDL_SCANCODE_J, IN_SC_J);
+		INL_MapKey(SDL_SCANCODE_K, IN_SC_K);
+		INL_MapKey(SDL_SCANCODE_L, IN_SC_L);
+		INL_MapKey(SDL_SCANCODE_M, IN_SC_M);
+		INL_MapKey(SDL_SCANCODE_N, IN_SC_N);
+		INL_MapKey(SDL_SCANCODE_O, IN_SC_O);
+		INL_MapKey(SDL_SCANCODE_P, IN_SC_P);
+		INL_MapKey(SDL_SCANCODE_Q, IN_SC_Q);
+		INL_MapKey(SDL_SCANCODE_R, IN_SC_R);
+		INL_MapKey(SDL_SCANCODE_S, IN_SC_S);
+		INL_MapKey(SDL_SCANCODE_T, IN_SC_T);
+		INL_MapKey(SDL_SCANCODE_U, IN_SC_U);
+		INL_MapKey(SDL_SCANCODE_V, IN_SC_V);
+		INL_MapKey(SDL_SCANCODE_W, IN_SC_W);
+		INL_MapKey(SDL_SCANCODE_X, IN_SC_X);
+		INL_MapKey(SDL_SCANCODE_Y, IN_SC_Y);
+		INL_MapKey(SDL_SCANCODE_Z, IN_SC_Z);
+
+		// Keypad keys (used as num-lock is toggled *off*, more or less)
+
+		INL_MapKey(SDL_SCANCODE_KP_DIVIDE, IN_SC_Slash);
+		INL_MapKey(SDL_SCANCODE_KP_MULTIPLY, IN_KP_Multiply);
+		INL_MapKey(SDL_SCANCODE_KP_MINUS, IN_KP_Minus);
+		INL_MapKey(SDL_SCANCODE_KP_PLUS, IN_KP_Plus);
+		INL_MapKey(SDL_SCANCODE_KP_ENTER, IN_SC_Enter);
+		INL_MapKey(SDL_SCANCODE_KP_PERIOD, IN_SC_Delete);
+		INL_MapKey(SDL_SCANCODE_KP_1, IN_SC_End);
+		INL_MapKey(SDL_SCANCODE_KP_2, IN_SC_DownArrow);
+		INL_MapKey(SDL_SCANCODE_KP_3, IN_SC_PgDown);
+		INL_MapKey(SDL_SCANCODE_KP_4, IN_SC_LeftArrow);
+		INL_MapKey(SDL_SCANCODE_KP_5, IN_KP_Center);
+		INL_MapKey(SDL_SCANCODE_KP_6, IN_SC_RightArrow);
+		INL_MapKey(SDL_SCANCODE_KP_7, IN_SC_Home);
+		INL_MapKey(SDL_SCANCODE_KP_8, IN_SC_UpArrow);
+		INL_MapKey(SDL_SCANCODE_KP_9, IN_SC_PgUp);
+		INL_MapKey(SDL_SCANCODE_KP_0, IN_SC_Insert);
+
+		INL_MapKey(SDL_SCANCODE_NONUSBACKSLASH, IN_SC_SecondaryBackSlash);
+
+	default:
+		return IN_SC_Invalid;
+	}
+}
+
+#undef INL_MapKey
+
+static void IN_SDL_HandleSDLEvent(SDL_Event *event)
+{
+
+	IN_ScanCode sc;
+	static bool special;
+
+	switch (event->type)
+	{
+	case SDL_EVENT_QUIT:
+		Quit(0);
+		break;
+	case SDL_EVENT_KEY_DOWN:
+		sc = INL_SDLKeySymToScanCode(&event->key);
+
+		if (sc == 0xe0) // Special key prefix
+			special = true;
+		else
+		{
+			IN_HandleKeyDown(sc, special);
+			special = false;
+		}
+
+		break;
+	case SDL_EVENT_KEY_UP:
+		sc = INL_SDLKeySymToScanCode(&event->key);
+		IN_HandleKeyUp(sc, false);
+		break;
+	case SDL_EVENT_TEXT_INPUT:
+		IN_HandleTextEvent(event->text.text);
+		break;
+	case SDL_EVENT_JOYSTICK_ADDED:
+		INL_StartJoy(event->jdevice.which);
+		break;
+	case SDL_EVENT_JOYSTICK_REMOVED:
+		for (int i = 0; i < IN_MAX_JOYSTICKS; ++i)
+		{
+			if (SDL_GetJoystickID(in_joysticks[i]) == event->jdevice.which)
+				INL_StopJoy(i);
+		}
+		break;
+	}
+}
+
+void IN_SDL_PumpEvents()
+{
+	SDL_Event event;
+	while (SDL_PollEvent(&event))
+		IN_SDL_HandleSDLEvent(&event);
+}
+
+void IN_SDL_WaitKey()
+{
+	SDL_Event event;
+	while (SDL_WaitEvent(&event))
+	{
+		IN_SDL_HandleSDLEvent(&event);
+		if (event.type == SDL_EVENT_KEY_DOWN)
+			break;
+	}
+}
+
+void IN_SDL_Startup(bool disableJoysticks)
+{
+	if (!disableJoysticks)
+	{
+		SDL_Init(SDL_INIT_JOYSTICK);
+		int numJoys;
+		const SDL_JoystickID *joys = SDL_GetJoysticks(&numJoys);
+		for (int i = 0; i < numJoys; ++i)
+			INL_StartJoy(joys[i]);
+	}
+}
+
+bool IN_SDL_StartJoy(int joystick)
+{
+	int joystick_id = -1;
+
+	// On SDL2, with hotplug support, we can get hotplug events for joysticks
+	// we've already got open. Check we don't have any duplicates here.
+	SDL_GUID newGUID = SDL_GetJoystickGUIDForID(joystick);
+	for (int i = 0; i < IN_MAX_JOYSTICKS; ++i)
+	{
+		if (in_joystickPresent[i])
+		{
+			SDL_GUID GUID_i = SDL_GetJoystickGUID(in_joysticks[i]);
+			if (!memcmp((void *)&newGUID, (void *)&GUID_i, sizeof(SDL_GUID)))
+				return false;
+		}
+	}
+
+	// Find an available joystick ID.
+	for (int i = 0; i < IN_MAX_JOYSTICKS; ++i)
+	{
+		if (!in_joystickPresent[i])
+		{
+			joystick_id = i;
+			break;
+		}
+	}
+
+	if (joystick_id == -1)
+		return false;
+
+	in_joysticks[joystick_id] = SDL_OpenJoystick(joystick);
+
+	in_joystickPresent[joystick_id] = true;
+
+	in_joystickHasHat[joystick_id] = (SDL_GetNumJoystickHats(in_joysticks[joystick_id]) > 0);
+
+	if (SDL_IsGamepad(joystick))
+	{
+		in_controllers[joystick_id] = SDL_OpenGamepad(joystick);
+	}
+
+	return true;
+}
+
+void IN_SDL_StopJoy(int joystick)
+{
+	in_joystickPresent[joystick] = false;
+	if (in_controllers[joystick])
+		SDL_CloseGamepad(in_controllers[joystick]);
+
+	SDL_CloseJoystick(in_joysticks[joystick]);
+}
+
+bool IN_SDL_JoyPresent(int joystick)
+{
+	return in_joystickPresent[joystick];
+}
+
+void IN_SDL_JoyGetAbs(int joystick, int *x, int *y)
+{
+	int value_x = SDL_GetJoystickAxis(in_joysticks[joystick], 0);
+	int value_y = SDL_GetJoystickAxis(in_joysticks[joystick], 1);
+#if !defined(CK_VANILLA)
+	static const int HAT = 32000;
+	if (in_joystickHasHat[joystick]) {
+		switch (SDL_GetJoystickHat(in_joysticks[joystick], 0)) {
+			case SDL_HAT_LEFTUP:     value_x = -HAT;  value_y = -HAT;  break;
+			case SDL_HAT_UP:                          value_y = -HAT;  break;
+			case SDL_HAT_RIGHTUP:    value_x = +HAT;  value_y = -HAT;  break;
+			case SDL_HAT_LEFT:       value_x = -HAT;                   break;
+			case SDL_HAT_RIGHT:      value_x = +HAT;                   break;
+			case SDL_HAT_LEFTDOWN:   value_x = -HAT;  value_y = +HAT;  break;
+			case SDL_HAT_DOWN:                        value_y = +HAT;  break;
+			case SDL_HAT_RIGHTDOWN:  value_x = +HAT;  value_y = +HAT;  break;
+			default:                                                   break;
+		}
+	}
+#endif
+	if (x)
+		*x = value_x;
+	if (y)
+		*y = value_y;
+}
+
+uint16_t IN_SDL_JoyGetButtons(int joystick)
+{
+	uint16_t mask = 0;
+	int i, n = SDL_GetNumJoystickButtons(in_joysticks[joystick]);
+	if (n > 16)
+		n = 16;  /* the mask is just 16 bits wide anyway */
+	for (i = 0;  i < n;  i++)
+	{
+		if (in_controllers[joystick])
+			mask |= SDL_GetGamepadButton(in_controllers[joystick], (SDL_GamepadButton)i) << i;
+		else
+		mask |= SDL_GetJoystickButton(in_joysticks[joystick], i) << i;
+	}
+	return mask;
+}
+
+const char* IN_SDL_JoyGetName(int joystick)
+{
+	return SDL_GetJoystickName(in_joysticks[joystick]);
+}
+
+const char* IN_SDL_JoyGetButtonName(int joystick, int index)
+{
+	if (in_controllers[joystick])
+	{
+		return SDL_GetGamepadStringForButton((SDL_GamepadButton)index);
+	}
+	return NULL;
+}
+
+extern SDL_Window *vl_sdl3_window;
+
+void IN_SDL_StartTextInput(const char *reason, const char *oldText)
+{
+	SDL_StartTextInput(vl_sdl3_window);
+}
+
+void IN_SDL_StopTextInput()
+{
+	SDL_StopTextInput(vl_sdl3_window);
+}
+
+IN_Backend in_sdl_backend = {
+	.startup = IN_SDL_Startup,
+	.shutdown = 0,
+	.pumpEvents = IN_SDL_PumpEvents,
+	.waitKey = IN_SDL_WaitKey,
+	.joyStart = IN_SDL_StartJoy,
+	.joyStop = IN_SDL_StopJoy,
+	.joyPresent = IN_SDL_JoyPresent,
+	.joyGetAbs = IN_SDL_JoyGetAbs,
+	.joyGetButtons = IN_SDL_JoyGetButtons,
+	.joyGetName = IN_SDL_JoyGetName,
+	.joyGetButtonName = IN_SDL_JoyGetButtonName,
+	.startTextInput = IN_SDL_StartTextInput,
+	.stopTextInput = IN_SDL_StopTextInput,
+	.joyAxisMin = -32768,
+	.joyAxisMax =  32767,
+	.supportsTextEvents = true,
+};
+
+IN_Backend *IN_Impl_GetBackend()
+{
+	return &in_sdl_backend;
+}

--- a/src/id_sd_sdl3.c
+++ b/src/id_sd_sdl3.c
@@ -1,0 +1,606 @@
+
+//
+//      ID Engine
+//      ID_SD.c - Sound Manager for Wolfenstein 3D
+//      v1.2
+//      By Jason Blochowiak
+//
+
+//
+//      This module handles dealing with generating sound on the appropriate
+//              hardware
+//
+//      Depends on: User Mgr (for parm checking)
+//
+//      Globals:
+//              For User Mgr:
+//                      SoundBlasterPresent - SoundBlaster card present?
+//                      AdLibPresent - AdLib card present?
+//                      SoundMode - What device is used for sound effects
+//                              (Use SM_SetSoundMode() to set)
+//                      MusicMode - What device is used for music
+//                              (Use SM_SetMusicMode() to set)
+//                      DigiMode - What device is used for digitized sound effects
+//                              (Use SM_SetDigiDevice() to set)
+//
+//              For Cache Mgr:
+//                      NeedsDigitized - load digitized sounds?
+//                      NeedsMusic - load music?
+//
+
+#include <SDL3/SDL.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "id_cfg.h"
+#include "id_sd.h"
+#include "id_us.h"
+#include "ck_cross.h"
+
+#include "opl/dbopl.h"
+#include "opl/nuked_opl3.h"
+
+#define SD_SDL_WITH_QUEUEAUDIO
+// Are we using the SDL_PutAudioStreamData function?
+static bool sd_sdl_queueAudio = true;
+static int sd_sdl_queueAudioMinBufSize = 0;
+
+static int sd_oplDelaySamples;
+static bool sd_nukedBufferWrites;
+
+#define PC_PIT_RATE 1193182
+#define SD_SFX_PART_RATE 140
+/* In the original exe, upon setting a rate of 140Hz or 560Hz for some
+ * interrupt handler, the value 1192030 divided by the desired rate is
+ * calculated, to be programmed for timer 0 as a consequence.
+ * For THIS value, it is rather 1193182 that should be divided by it, in order
+ * to obtain a better approximation of the actual rate.
+ */
+#define SD_SOUND_PART_RATE_BASE 1192030
+
+// Sort of replacements for x86 behaviors and assembly code
+static bool SD_PC_Speaker_On;
+static int16_t SD_SDL_CurrentBeepSample;
+static uint32_t SD_SDL_BeepHalfCycleCounter, SD_SDL_BeepHalfCycleCounterUpperBound;
+
+// WARNING: These vars refer to the libSDL library!!!
+SDL_AudioSpec SD_SDL_AudioSpec;
+static bool SD_SDL_AudioSubsystem_Up;
+static uint64_t SD_SDL_ScaledSamplesPerPartsTimesPITRate;
+static uint32_t SD_SDL_ScaledSamplesPartNum = 0;
+static uint32_t SD_SDL_SampleOffsetInSound, SD_SDL_SamplesInCurrentPart;
+
+// Used for filling with samples from alOut (alOut_lLw), in addition
+// to SD_SDL_CallBack (because waits between/after AdLib writes are expected)
+static int16_t SD_ALOut_Samples[512 * 2];
+static uint32_t SD_ALOut_SamplesStart = 0, SD_ALOut_SamplesEnd = 0;
+
+// Used for the timer fallback.
+static volatile int SD_SDL_timerDivisor = 1;
+static volatile bool SD_SDL_useTimerFallback = false;
+static uint64_t SD_SDL_nextTickAt = 0;
+static SDL_Thread *SD_SDL_t0Thread = 0;
+static SDL_Mutex *sd_sdl3_audioMutex;
+
+static SDL_Condition *SD_SDL_TimerConditionVar;
+static bool SD_SDL_WaitTicksSpin = false;
+
+SDL_AudioStream *sd_sdl3_audioDevice;
+
+/* NEVER call this from the SDL callback!!! (Or you want a deadlock?) */
+void SD_SDL_SetTimer0(int16_t int_8_divisor)
+{
+	SD_SDL_ScaledSamplesPerPartsTimesPITRate = int_8_divisor * SD_SDL_AudioSpec.freq;
+	// Since the following division may lead to truncation, SD_SDL_SamplesInCurrentPart
+	// can change during playback by +-1 (otherwise music may be a bit faster than intended).
+	SD_SDL_SamplesInCurrentPart = SD_SDL_ScaledSamplesPerPartsTimesPITRate / PC_PIT_RATE;
+
+	// For the timer fallback.
+	SD_SDL_timerDivisor = int_8_divisor;
+}
+
+/*******************************************************************************
+OPL emulation, powered by dbopl from DOSBox and using bits of code from Wolf4SDL
+*******************************************************************************/
+
+typedef enum SD_OPLEmulator
+{
+	SD_OPL_EMULATOR_NONE,
+	SD_OPL_EMULATOR_DBOPL,
+	SD_OPL_EMULATOR_NUKED
+} SD_OPLEmulator;
+
+static SD_OPLEmulator sd_oplEmulator;
+
+Chip oplChip;
+opl3_chip nuked_oplChip;
+int numChannels;
+
+static inline bool YM3812Init(int numChips, int clock, int rate)
+{
+	if (sd_oplEmulator == SD_OPL_EMULATOR_DBOPL)
+	{
+		DBOPL_InitTables();
+		Chip__Chip(&oplChip);
+		Chip__Setup(&oplChip, rate);
+	}
+	else if (sd_oplEmulator == SD_OPL_EMULATOR_NUKED)
+	{
+		OPL3_Reset(&nuked_oplChip, rate);
+	}
+	return false;
+}
+
+static inline void YM3812Write(Chip *which, Bit32u reg, Bit8u val)
+{
+	if (sd_oplEmulator == SD_OPL_EMULATOR_DBOPL)
+	{
+		Chip__WriteReg(which, reg, val);
+	}
+	else if (sd_oplEmulator == SD_OPL_EMULATOR_NUKED)
+	{
+		if (sd_nukedBufferWrites)
+			OPL3_WriteRegBuffered(&nuked_oplChip, reg, val);
+		else
+			OPL3_WriteReg(&nuked_oplChip, reg, val);
+	}
+}
+
+static inline void YM3812UpdateOne(Chip *which, int16_t *stream, int length)
+{
+	if (sd_oplEmulator == SD_OPL_EMULATOR_DBOPL)
+	{
+		Bit32s buffer[512 * 2];
+		int i;
+
+		// length is at maximum samplesPerMusicTick = param_samplerate / 700
+		// so 512 is sufficient for a sample rate of 358.4 kHz (default 44.1 kHz)
+		if (length > 512)
+			length = 512;
+
+		if(which->opl3Active)
+		{
+			Chip__GenerateBlock3(which, length, buffer);
+
+			// GenerateBlock3 generates a number of "length" 32-bit stereo samples
+			// so we need to convert them to 16-bit mono samples
+			if (numChannels == 1)
+			{
+				for(i = 0; i < length; i++)
+				{
+					int32_t sample = buffer[i*2] + buffer[i*2+1];
+					if(sample > 16383) sample = 16383;
+					else if(sample < -16384) sample = -16384;
+					stream[i] = sample;
+				}
+			}
+			else if (numChannels == 2)
+			{
+				for(i = 0; i < length * 2; i++)
+				{
+					int32_t sample = buffer[i];
+					if(sample > 16383) sample = 16383;
+					else if(sample < -16384) sample = -16384;
+					stream[i] = sample;
+				}
+			}
+
+		}
+		else
+		{
+			Chip__GenerateBlock2(which, length, buffer);
+
+			// GenerateBlock2 generates a number of "length" 32-bit mono samples
+			// so we only need to convert them to 16-bit mono samples
+			if (numChannels == 1)
+			{
+				for (i = 0; i < length; i++)
+				{
+					// Scale volume
+					Bit32s sample = 2 * buffer[i];
+					if (sample > 16383)
+						sample = 16383;
+					else if (sample < -16384)
+						sample = -16384;
+					stream[i] = (int16_t)sample;
+				}
+			}
+			else if (numChannels == 2)
+			{
+				for (i = 0; i < length; i++)
+				{
+					// Scale volume
+					Bit32s sample = 2 * buffer[i];
+					if (sample > 16383)
+						sample = 16383;
+					else if (sample < -16384)
+						sample = -16384;
+					stream[i*2] = (int16_t)sample;
+					stream[i*2+1] = (int16_t)sample;
+				}
+			}
+		}
+	}
+	else if (sd_oplEmulator == SD_OPL_EMULATOR_NUKED)
+	{
+		// Nuked OPL3 always generates stereo, but Omnispeak often uses
+		// mono streams.
+		int16_t buffer[512 * 2];
+		int offset = 0;
+
+		while (length)
+		{
+			// The length should really never be 512 samples,
+			// (see above for the DBOPL driver), but nevertheless
+			// we handle the case. (Maybe someone's running at an
+			// absurd sample rate.)
+			int chunkLen = CK_Cross_min(length, 512);
+
+
+
+			if (numChannels == 1)
+			{
+				OPL3_GenerateStream(&nuked_oplChip, buffer, chunkLen);
+				for (int i = 0; i < chunkLen; i++)
+				{
+					// Add L + R to get a mono sample
+					int32_t sample = buffer[i*2] + buffer[i*2+1];
+					// We store it temporarily in a 32-bit value,
+					// then clamp the result to 16-bit. This will
+					// sound bad, but better than integer overflow.
+					if (sample > 32767)
+						sample = 32767;
+					else if (sample < -32768)
+						sample = -32768;
+					stream[offset + i] = (int16_t)sample;
+				}
+			}
+			else if (numChannels == 2)
+			{
+				OPL3_GenerateStream(&nuked_oplChip, stream + offset * 2, chunkLen);
+			}
+			length -= chunkLen;
+			offset += chunkLen;
+		}
+	}
+}
+
+static int sd_sdl_bonusSamplesQueued = 0;
+
+static inline void PCSpeakerUpdateOne(int16_t *stream, int length);
+void SD_SDL_alOut(uint8_t reg, uint8_t val)
+{
+	// FIXME: The original code for alOut adds 6 reads of the register port
+	// after writing to it (3.3 microseconds), and then 35 more reads of
+	// the register port after writing to the data port (23 microseconds).
+	//
+	// It is apparently important for a portion of the fuse breakage sound
+	// at the least. For now a hack is implied.
+	YM3812Write(&oplChip, reg, val);
+	// Hack comes with a "magic number" that appears to make it work better
+	int length = sd_oplDelaySamples;
+	if (length)
+	{
+		if (sd_sdl_queueAudio)
+		{
+			YM3812UpdateOne(&oplChip, SD_ALOut_Samples, length);
+			if (SD_PC_Speaker_On)
+				PCSpeakerUpdateOne(SD_ALOut_Samples, length);
+			SDL_PutAudioStreamData(sd_sdl3_audioDevice, SD_ALOut_Samples, length * numChannels * 2);
+			sd_sdl_bonusSamplesQueued += length;
+		}
+		else
+		{
+			if (length > sizeof(SD_ALOut_Samples) / (sizeof(int16_t) * numChannels) - SD_ALOut_SamplesEnd)
+				length = sizeof(SD_ALOut_Samples) / (sizeof(int16_t) * numChannels) - SD_ALOut_SamplesEnd;
+			YM3812UpdateOne(&oplChip, &SD_ALOut_Samples[SD_ALOut_SamplesEnd * numChannels], length);
+			SD_ALOut_SamplesEnd += length;
+		}
+	}
+}
+
+/************************************************************************
+PC Speaker emulation; The function mixes audio
+into an EXISTING stream (of OPL sound data)
+ASSUMPTION: The speaker is outputting sound (PCSpeakerUpdateOne == true).
+************************************************************************/
+static inline void PCSpeakerUpdateOne(int16_t *stream, int length)
+{
+	for (int loopVar = 0; loopVar < length; loopVar++)
+	{
+		*stream = (*stream + SD_SDL_CurrentBeepSample) / 2; // Mix
+		stream++;
+		if (numChannels == 2)
+		{
+			*stream = (*stream + SD_SDL_CurrentBeepSample) / 2; // Mix
+			stream++;
+		}
+		SD_SDL_BeepHalfCycleCounter += 2 * PC_PIT_RATE;
+		if (SD_SDL_BeepHalfCycleCounter >= SD_SDL_BeepHalfCycleCounterUpperBound)
+		{
+			SD_SDL_BeepHalfCycleCounter %= SD_SDL_BeepHalfCycleCounterUpperBound;
+			// 32767 - too loud
+			SD_SDL_CurrentBeepSample = 24575 - SD_SDL_CurrentBeepSample;
+		}
+	}
+}
+
+/* FIXME: The SDL prefix may conflict with SDL functions in the future(???)
+ * Best (but hackish) solution, if it happens: Add our own custom prefix.
+ */
+
+void SDL_t0Service(void);
+
+// WARNING: This function refers to the libSDL library!!!
+/* BIG BIG FIXME: This is the VERY wrong place to call the OPL emulator, etc! */
+void SD_SDL_CallBack(void *unused, Uint8 *stream, int len)
+{
+	int16_t *currSamplePtr = (int16_t *)stream;
+	uint32_t currNumOfSamples;
+	bool isPartCompleted;
+#if SDL_VERSION_ATLEAST(1, 3, 0)
+	memset(stream, 0, len);
+#endif
+	while (len)
+	{
+		if (!SD_SDL_SampleOffsetInSound && !SD_SDL_useTimerFallback)
+		{
+			SDL_t0Service();
+			if (!SD_SDL_WaitTicksSpin)
+				SDL_BroadcastCondition(SD_SDL_TimerConditionVar);
+		}
+		// Now generate sound
+		isPartCompleted = (len >= 2 * numChannels * (SD_SDL_SamplesInCurrentPart - SD_SDL_SampleOffsetInSound));
+		currNumOfSamples = isPartCompleted ? (SD_SDL_SamplesInCurrentPart - SD_SDL_SampleOffsetInSound) : (len / (2 * numChannels));
+
+		// AdLib (including hack for alOut delays)
+		if (SD_ALOut_SamplesEnd - SD_ALOut_SamplesStart <= currNumOfSamples)
+		{
+			// Copy sound generated by alOut
+			if (SD_ALOut_SamplesEnd - SD_ALOut_SamplesStart > 0)
+				memcpy(currSamplePtr, &SD_ALOut_Samples[SD_ALOut_SamplesStart * numChannels], numChannels * 2 * (SD_ALOut_SamplesEnd - SD_ALOut_SamplesStart));
+			// Generate what's left
+			if (currNumOfSamples - (SD_ALOut_SamplesEnd - SD_ALOut_SamplesStart) > 0)
+				YM3812UpdateOne(&oplChip, currSamplePtr + (SD_ALOut_SamplesEnd - SD_ALOut_SamplesStart) * numChannels, currNumOfSamples - (SD_ALOut_SamplesEnd - SD_ALOut_SamplesStart));
+			// Finally update these
+			SD_ALOut_SamplesStart = SD_ALOut_SamplesEnd = 0;
+		}
+		else
+		{
+			// Already generated enough by alOut, to be copied
+			memcpy(currSamplePtr, &SD_ALOut_Samples[SD_ALOut_SamplesStart], 2 * numChannels * currNumOfSamples);
+			SD_ALOut_SamplesStart += currNumOfSamples;
+		}
+		// PC Speaker
+		if (SD_PC_Speaker_On)
+			PCSpeakerUpdateOne(currSamplePtr, currNumOfSamples);
+		// We're done for now
+		currSamplePtr += currNumOfSamples * numChannels;
+		SD_SDL_SampleOffsetInSound += currNumOfSamples;
+		len -= 2 * numChannels * currNumOfSamples;
+		// End of part?
+		if (SD_SDL_SampleOffsetInSound >= SD_SDL_SamplesInCurrentPart)
+		{
+			SD_SDL_SampleOffsetInSound = 0;
+			if (++SD_SDL_ScaledSamplesPartNum == PC_PIT_RATE)
+				SD_SDL_ScaledSamplesPartNum = 0;
+
+			SD_SDL_SamplesInCurrentPart = (SD_SDL_ScaledSamplesPartNum + 1) * SD_SDL_ScaledSamplesPerPartsTimesPITRate / PC_PIT_RATE - SD_SDL_ScaledSamplesPartNum * SD_SDL_ScaledSamplesPerPartsTimesPITRate / PC_PIT_RATE;
+		}
+	}
+}
+
+int SD_SDL_t0InterruptThread(void *param)
+{
+	while (SD_SDL_useTimerFallback)
+	{
+		uint64_t currPitTicks = (uint64_t)(SDL_GetPerformanceCounter()) * PC_PIT_RATE / SDL_GetPerformanceFrequency();
+		// Top up to min buffer size if below.
+		if (SD_SDL_AudioSubsystem_Up && sd_sdl_queueAudio && sd_sdl_queueAudioMinBufSize)
+		{
+			int curQueueLen = SDL_GetAudioStreamQueued(sd_sdl3_audioDevice) / (numChannels * sizeof(int16_t));
+			if (curQueueLen < sd_sdl_queueAudioMinBufSize)
+			{
+				int length = sd_sdl_queueAudioMinBufSize - curQueueLen;
+				YM3812UpdateOne(&oplChip, SD_ALOut_Samples, length);
+				if (SD_PC_Speaker_On)
+					PCSpeakerUpdateOne(SD_ALOut_Samples, length);
+				SDL_PutAudioStreamData(sd_sdl3_audioDevice, SD_ALOut_Samples, length * numChannels * sizeof(int16_t));
+				sd_sdl_bonusSamplesQueued -= length;
+				if (sd_sdl_bonusSamplesQueued < 0)
+					sd_sdl_bonusSamplesQueued = 0;
+			}
+		}
+
+		if (currPitTicks >= SD_SDL_nextTickAt)
+		{
+			SDL_LockMutex(sd_sdl3_audioMutex);
+			SDL_t0Service();
+			SDL_UnlockMutex(sd_sdl3_audioMutex);
+			if (!SD_SDL_WaitTicksSpin)
+				SDL_BroadcastCondition(SD_SDL_TimerConditionVar);
+			SD_SDL_nextTickAt += SD_SDL_timerDivisor;
+			if (SD_SDL_AudioSubsystem_Up && sd_sdl_queueAudio)
+			{
+				int length = SD_SDL_SamplesInCurrentPart - sd_sdl_bonusSamplesQueued;
+				sd_sdl_bonusSamplesQueued -= SD_SDL_SamplesInCurrentPart;
+				if (sd_sdl_bonusSamplesQueued < 0) sd_sdl_bonusSamplesQueued = 0;
+				if (length < 1) continue;
+				YM3812UpdateOne(&oplChip, SD_ALOut_Samples, length);
+				if (SD_PC_Speaker_On)
+					PCSpeakerUpdateOne(SD_ALOut_Samples, length);
+				SDL_PutAudioStreamData(sd_sdl3_audioDevice, SD_ALOut_Samples, length * numChannels * sizeof(int16_t));
+				if (++SD_SDL_ScaledSamplesPartNum == PC_PIT_RATE)
+					SD_SDL_ScaledSamplesPartNum = 0;
+
+				SD_SDL_SamplesInCurrentPart = (SD_SDL_ScaledSamplesPartNum + 1) * SD_SDL_ScaledSamplesPerPartsTimesPITRate / PC_PIT_RATE - SD_SDL_ScaledSamplesPartNum * SD_SDL_ScaledSamplesPerPartsTimesPITRate / PC_PIT_RATE;
+			}
+		}
+		else
+		{
+			uint64_t ticksRemaining = SD_SDL_nextTickAt - currPitTicks;
+			uint64_t platformTicks = ticksRemaining * 1000 / PC_PIT_RATE;
+
+			if (platformTicks > 5000)
+			{
+				/* If we're more than 5 seconds behind, just reset. */
+				SD_SDL_nextTickAt = currPitTicks;
+			}
+			else
+				SDL_Delay(platformTicks);
+		}
+	}
+	return 0;
+}
+
+void SD_SDL_PCSpkOn(bool on, int freq)
+{
+	SD_PC_Speaker_On = on;
+	SD_SDL_CurrentBeepSample = 0;
+	SD_SDL_BeepHalfCycleCounter = 0;
+	SD_SDL_BeepHalfCycleCounterUpperBound = SD_SDL_AudioSpec.freq * freq;
+}
+
+void SD_SDL_Startup(void)
+{
+	const char *oplEmuString = CFG_GetConfigString("oplEmulator", "dbopl");
+	if (!CK_Cross_strcasecmp(oplEmuString, "nukedopl3"))
+		sd_oplEmulator = SD_OPL_EMULATOR_NUKED;
+	else if (!CK_Cross_strcasecmp(oplEmuString, "dbopl"))
+		sd_oplEmulator = SD_OPL_EMULATOR_DBOPL;
+	else
+	{
+		CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Unknown OPL emulator \"%s\". Valid values are \"dbopl\" and \"nukedopl3\".\n", oplEmuString);
+		sd_oplEmulator = SD_OPL_EMULATOR_DBOPL;
+	}
+
+	SD_SDL_useTimerFallback = true;
+
+	for (int i = 0; i < us_argc; ++i)
+	{
+		if (!CK_Cross_strcasecmp(us_argv[i], "/NUKEDOPL3"))
+			sd_oplEmulator = SD_OPL_EMULATOR_NUKED;
+	}
+
+	// Check if we should use SDL_PutAudioStreamData
+	sd_sdl_queueAudioMinBufSize = CFG_GetConfigInt("sd_sdl_queueAudioMinBufSize", 0);
+
+	SD_SDL_AudioSpec.freq = CFG_GetConfigInt("sampleRate", 49716); // OPL rate
+	SD_SDL_AudioSpec.format = SDL_AUDIO_S16;
+	SD_SDL_AudioSpec.channels = CFG_GetConfigInt("audioChannels", 2);
+	sd_oplDelaySamples = CFG_GetConfigInt("sd_oplDelaySamples", SD_SDL_AudioSpec.freq / 10000);
+	sd_nukedBufferWrites = CFG_GetConfigBool("sd_nukedBufferWrites", sd_oplDelaySamples == 0);
+
+	// Setup a condition variable to signal threads waiting for timer updates.
+	SD_SDL_WaitTicksSpin = CFG_GetConfigBool("sd_sdl_waitTicksSpin", false);
+	if (!SD_SDL_WaitTicksSpin)
+		SD_SDL_TimerConditionVar = SDL_CreateCondition();
+
+	// Allow us to override the audio driver.
+	const char *defaultDriver = NULL;
+	const char *sdlDriver = CFG_GetConfigString("sd_sdl_audioDriver", defaultDriver);
+	SDL_SetHint(SDL_HINT_AUDIO_DRIVER, sdlDriver);
+
+	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
+	{
+		CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "SDL audio system initialization failed,\n%s\n", SDL_GetError());
+		SD_SDL_AudioSubsystem_Up = false;
+		SD_SDL_useTimerFallback = true;
+	}
+	else
+	{
+		sd_sdl3_audioDevice = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &SD_SDL_AudioSpec, NULL, NULL);
+		if (!sd_sdl3_audioDevice)
+		{
+			CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Cannot open SDL audio device,\n%s\n", SDL_GetError());
+			SDL_QuitSubSystem(SDL_INIT_AUDIO);
+			SD_SDL_AudioSubsystem_Up = false;
+		}
+		else
+		{
+			SD_SDL_AudioSubsystem_Up = true;
+			numChannels = SD_SDL_AudioSpec.channels;
+			CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "SD_SDL3_Startup: Initialised device %s at %d Hz, %d Channels\n", SDL_GetAudioDeviceName(SDL_GetAudioStreamDevice(sd_sdl3_audioDevice)), SD_SDL_AudioSpec.freq, numChannels);
+		}
+
+		if (YM3812Init(1, 3579545, SD_SDL_AudioSpec.freq))
+		{
+			CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Preparation of emulated OPL chip has failed\n");
+		}
+
+		// Make sure we have all of these variables initialised to
+		// sendible values before we start the audio callback, or we can
+		// end up deadlocking, as the callback can run forever.
+		SD_SDL_SetTimer0(8514);
+		SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(sd_sdl3_audioDevice));
+	}
+	// Start the timer fallback if needed.
+	if (SD_SDL_useTimerFallback)
+	{
+		uint64_t currPitTicks = (uint64_t)(SDL_GetPerformanceCounter()) * PC_PIT_RATE / SDL_GetPerformanceFrequency();
+		SD_SDL_nextTickAt = currPitTicks;
+		SD_SDL_t0Thread = SDL_CreateThread(SD_SDL_t0InterruptThread, "ID_SD: t0 interrupt thread.", NULL);
+	}
+}
+
+void SD_SDL_Shutdown(void)
+{
+	if (SD_SDL_useTimerFallback)
+	{
+		SD_SDL_useTimerFallback = false;
+		SDL_WaitThread(SD_SDL_t0Thread, NULL);
+	}
+	if (SD_SDL_AudioSubsystem_Up)
+	{
+		SDL_DestroyAudioStream(sd_sdl3_audioDevice);
+		SDL_DestroyMutex(sd_sdl3_audioMutex);
+		SDL_QuitSubSystem(SDL_INIT_AUDIO);
+		SD_SDL_AudioSubsystem_Up = false;
+	}
+}
+
+bool SD_SDL_IsLocked = false;
+
+void SD_SDL_Lock()
+{
+	if (SD_SDL_IsLocked)
+		CK_Cross_LogMessage(CK_LOG_MSG_ERROR, "Tried to lock the audio system when it was already locked!\n");
+	if (SD_SDL_AudioSubsystem_Up)
+		SDL_LockMutex(sd_sdl3_audioMutex);
+	SD_SDL_IsLocked = true;
+}
+
+void SD_SDL_Unlock()
+{
+	if (!SD_SDL_IsLocked)
+		CK_Cross_LogMessage(CK_LOG_MSG_ERROR, "Tried to unlock the audio system when it was already unlocked!\n");
+	if (SD_SDL_AudioSubsystem_Up)
+		SDL_UnlockMutex(sd_sdl3_audioMutex);
+	SD_SDL_IsLocked = false;
+}
+
+void SD_SDL_WaitTick()
+{
+	SDL_Mutex *mtx = SDL_CreateMutex();
+	SDL_LockMutex(mtx);
+	// Timeout of 2ms, as the PIT rate is ~1.1ms..
+	SDL_WaitConditionTimeout(SD_SDL_TimerConditionVar, mtx, 2);
+	SDL_UnlockMutex(mtx);
+}
+
+SD_Backend sd_sdl_backend = {
+	.startup = SD_SDL_Startup,
+	.shutdown = SD_SDL_Shutdown,
+	.lock = SD_SDL_Lock,
+	.unlock = SD_SDL_Unlock,
+	.alOut = SD_SDL_alOut,
+	.pcSpkOn = SD_SDL_PCSpkOn,
+	.setTimer0 = SD_SDL_SetTimer0,
+	.waitTick = SD_SDL_WaitTick};
+
+SD_Backend *SD_Impl_GetBackend()
+{
+	return &sd_sdl_backend;
+}

--- a/src/id_vl.c
+++ b/src/id_vl.c
@@ -26,9 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "id_us.h"
 
 #include <stdlib.h>
-#ifdef WITH_SDL
-#include <SDL.h>
-#endif
 
 // EGA color palette in RGB format (technically more can be chosen with the VGA)
 const uint8_t VL_EGARGBColorTable[16][3] = {

--- a/src/id_vl_sdl3.c
+++ b/src/id_vl_sdl3.c
@@ -1,0 +1,452 @@
+#include "assert.h"
+#include <SDL3/SDL.h>
+#include <string.h>
+#include "id_vl.h"
+#include "id_vl_private.h"
+#include "ck_cross.h"
+
+// We need the window to be exported so we can access it in ID_IN.
+SDL_Window *vl_sdl3_window;
+static SDL_Renderer *vl_sdl3_renderer;
+static SDL_Texture *vl_sdl3_texture;
+static SDL_Palette *vl_sdl3_palette;
+static SDL_Surface *vl_sdl3_stagingSurface;
+static SDL_Texture *vl_sdl3_scaledTarget;
+static bool vl_sdl3_bilinearSupport = true;
+
+static void VL_SDL3_ResizeWindow()
+{
+	int realWinH, realWinW, curW, curH;
+	SDL_GetCurrentRenderOutputSize(vl_sdl3_renderer, &realWinW, &realWinH);
+	VL_CalculateRenderRegions(realWinW, realWinH);
+
+	if (vl_sdl3_scaledTarget)
+	{
+		// Check if the scaled render target is the correct size.
+		SDL_PropertiesID props = SDL_GetTextureProperties(vl_sdl3_scaledTarget);
+		curW = SDL_GetNumberProperty(props, SDL_PROP_TEXTURE_WIDTH_NUMBER, 0);
+		curH = SDL_GetNumberProperty(props, SDL_PROP_TEXTURE_HEIGHT_NUMBER, 0);
+		if (curW == vl_integerWidth && curH == vl_integerHeight)
+		{
+			return;
+		}
+
+		// We need to recreate the scaled render target. Do so.
+		SDL_DestroyTexture(vl_sdl3_scaledTarget);
+		vl_sdl3_scaledTarget = 0;
+	}
+
+	if (!vl_isIntegerScaled)
+	{
+		vl_sdl3_scaledTarget = SDL_CreateTexture(vl_sdl3_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, vl_integerWidth, vl_integerHeight);
+		SDL_SetTextureScaleMode(vl_sdl3_scaledTarget, SDL_SCALEMODE_LINEAR);
+
+	}
+}
+
+void VL_SDL2GL_SetIcon(SDL_Window *wnd);
+
+static void VL_SDL3_SetVideoMode(int mode)
+{
+	if (mode == 0x0D)
+	{
+		SDL_Rect desktopBounds;
+		const SDL_DisplayID *displayIDs = SDL_GetDisplays(NULL);
+		if (!SDL_GetDisplayUsableBounds(*displayIDs, &desktopBounds))
+		{
+			CK_Cross_LogMessage(CK_LOG_MSG_ERROR, "Couldn't get usable display bounds to calculate default scale: \"%s\"\n", SDL_GetError());
+		}
+		int scale = VL_CalculateDefaultWindowScale(desktopBounds.w, desktopBounds.h);
+		vl_sdl3_window = SDL_CreateWindow(VL_WINDOW_TITLE,
+			VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale),
+			SDL_WINDOW_RESIZABLE | (vl_isFullScreen ? SDL_WINDOW_FULLSCREEN : 0));
+
+		SDL_SetWindowMinimumSize(vl_sdl3_window, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER / VL_VGA_GFX_WIDTH_SCALEFACTOR, VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER / VL_VGA_GFX_HEIGHT_SCALEFACTOR);
+
+		VL_SDL2GL_SetIcon(vl_sdl3_window);
+
+		SDL_PropertiesID renderProps = SDL_CreateProperties();
+		if (vl_swapInterval)
+			SDL_SetNumberProperty(renderProps, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, vl_swapInterval);
+#ifdef VL_SDL3_REQUEST_SOFTWARE
+		SDL_SetStringProperty(renderProps, SDL_PROP_RENDERER_CREATE_NAME_STRING, SDL_SOFTWARE_RENDERER);
+#endif
+		SDL_SetPointerProperty(renderProps, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, vl_sdl3_window);
+		vl_sdl3_renderer = SDL_CreateRendererWithProperties(renderProps);
+
+		if (!strcmp(SDL_GetRendererName(vl_sdl3_renderer), SDL_SOFTWARE_RENDERER))
+			vl_sdl3_bilinearSupport = false;
+
+		if (!vl_isIntegerScaled && !vl_sdl3_bilinearSupport)
+			CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Using SDL3 software renderer without integer scaling. Pixel size may be inconsistent.\n");
+
+		vl_sdl3_texture = SDL_CreateTexture(vl_sdl3_renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT);
+		SDL_SetTextureScaleMode(vl_sdl3_texture, SDL_SCALEMODE_NEAREST);
+
+		vl_sdl3_palette = SDL_CreatePalette(256);
+
+		// As we can't do on-GPU palette conversions with SDL3,
+		// we do a PAL8->RGBA conversion of the visible area to this surface each frame.
+		vl_sdl3_stagingSurface = SDL_CreateSurface(VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT, SDL_PIXELFORMAT_RGBA8888);
+
+		VL_SDL3_ResizeWindow();
+		SDL_HideCursor();
+	}
+	else
+	{
+		SDL_ShowCursor();
+		SDL_DestroyTexture(vl_sdl3_scaledTarget);
+		SDL_DestroyTexture(vl_sdl3_texture);
+		SDL_DestroyRenderer(vl_sdl3_renderer);
+		SDL_DestroyWindow(vl_sdl3_window);
+	}
+}
+
+static void VL_SDL3_SurfaceRect(void *dst_surface, int x, int y, int w, int h, int colour);
+static void *VL_SDL3_CreateSurface(int w, int h, VL_SurfaceUsage usage)
+{
+	SDL_Surface *s;
+	s = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_INDEX8);
+	return s;
+}
+
+static void VL_SDL3_DestroySurface(void *surface)
+{
+	//TODO: Implement
+}
+
+static long VL_SDL3_GetSurfaceMemUse(void *surface)
+{
+	SDL_Surface *surf = (SDL_Surface *)surface;
+	if (!surf)
+		return 0;
+	return surf->pitch * surf->h;
+}
+
+static void VL_SDL3_GetSurfaceDimensions(void *surface, int *w, int *h)
+{
+	SDL_Surface *surf = (SDL_Surface *)surface;
+	if (!surf)
+		return;
+	if (w)
+		*w = surf->w;
+	if (h)
+		*h = surf->h;
+}
+
+static void VL_SDL3_RefreshPaletteAndBorderColor(void *screen)
+{
+	SDL_Surface *surf = (SDL_Surface *)screen;
+	static SDL_Color sdl3_palette[16];
+
+	for (int i = 0; i < 16; i++)
+	{
+		sdl3_palette[i].r = VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][0];
+		sdl3_palette[i].g = VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][1];
+		sdl3_palette[i].b = VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][2];
+		sdl3_palette[i].a = 255;
+	}
+	SDL_SetPaletteColors(vl_sdl3_palette, sdl3_palette, 0, 16);
+	SDL_SetSurfacePalette(surf, vl_sdl3_palette);
+}
+
+static int VL_SDL3_SurfacePGet(void *surface, int x, int y)
+{
+	SDL_Surface *surf = (SDL_Surface *)surface;
+	SDL_LockSurface(surf);
+	int col = ((uint8_t *)surf->pixels)[y * surf->pitch + x];
+	SDL_UnlockSurface(surf);
+	return col;
+}
+
+static void VL_SDL3_SurfaceRect(void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_Rect rect = {(Sint16)x, (Sint16)y, (Uint16)w, (Uint16)h};
+	SDL_FillSurfaceRect(surf, &rect, colour);
+}
+
+static void VL_SDL3_SurfaceRect_PM(void *dst_surface, int x, int y, int w, int h, int colour, int mapmask)
+{
+	mapmask &= 0xF;
+	colour &= mapmask;
+
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	for (int py = y; py < y + h; py++)
+		for (int px = x; px < x + w; px++)
+		{
+			uint8_t *p = ((uint8_t *)surf->pixels) + py * surf->w + px;
+			*p &= ~mapmask;
+			*p |= colour;
+		}
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_SurfaceToSurface(void *src_surface, void *dst_surface, int x, int y, int sx, int sy, int sw, int sh)
+{
+	// Sadly we cannot naively use SDL_BlitSurface, since the surfaces may
+	// both be 8-bit but with different palettes, which we ignore.
+	SDL_Surface *surf = (SDL_Surface *)src_surface;
+	SDL_Surface *dest = (SDL_Surface *)dst_surface;
+
+	SDL_Rect srcr = {sx, sy, sw, sh};
+	SDL_Rect dstr = {x, y, 0, 0};
+
+	SDL_BlitSurface(surf, &srcr, dest, &dstr);
+}
+
+static void VL_SDL3_SurfaceToSelf(void *surface, int x, int y, int sx, int sy, int sw, int sh)
+{
+	SDL_Surface *srf = (SDL_Surface *)surface;
+	SDL_LockSurface(srf);
+	bool directionY = sy > y;
+
+	if (directionY)
+	{
+		for (int yi = 0; yi < sh; ++yi)
+		{
+			memmove((uint8_t *)srf->pixels + ((yi + y) * srf->pitch + x), (uint8_t *)srf->pixels + ((sy + yi) * srf->pitch + sx), sw);
+		}
+	}
+	else
+	{
+		for (int yi = sh - 1; yi >= 0; --yi)
+		{
+			memmove((uint8_t *)srf->pixels + ((yi + y) * srf->pitch + x), (uint8_t *)srf->pixels + ((sy + yi) * srf->pitch + sx), sw);
+		}
+	}
+
+	SDL_UnlockSurface(srf);
+}
+
+static void VL_SDL3_UnmaskedToSurface(void *src, void *dst_surface, int x, int y, int w, int h)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_UnmaskedToPAL8(src, surf->pixels, x, y, surf->pitch, w, h);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_UnmaskedToSurface_PM(void *src, void *dst_surface, int x, int y, int w, int h, int mapmask)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_UnmaskedToPAL8_PM(src, surf->pixels, x, y, surf->pitch, w, h, mapmask);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_MaskedToSurface(void *src, void *dst_surface, int x, int y, int w, int h)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_MaskedToPAL8(src, surf->pixels, x, y, surf->pitch, w, h);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_MaskedBlitToSurface(void *src, void *dst_surface, int x, int y, int w, int h)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_MaskedBlitClipToPAL8(src, surf->pixels, x, y, surf->pitch, w, h, surf->w, surf->h);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_BitToSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_1bppToPAL8(src, surf->pixels, x, y, surf->pitch, w, h, colour);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_BitToSurface_PM(void *src, void *dst_surface, int x, int y, int w, int h, int colour, int mapmask)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_1bppToPAL8_PM(src, surf->pixels, x, y, surf->pitch, w, h, colour, mapmask);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_BitXorWithSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_1bppXorWithPAL8(src, surf->pixels, x, y, surf->pitch, w, h, colour);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_BitBlitToSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_1bppBlitToPAL8(src, surf->pixels, x, y, surf->pitch, w, h, colour);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_BitInvBlitToSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	SDL_Surface *surf = (SDL_Surface *)dst_surface;
+	SDL_LockSurface(surf);
+	VL_1bppInvBlitClipToPAL8(src, surf->pixels, x, y, surf->pitch, w, h, surf->w, surf->h, colour);
+	SDL_UnlockSurface(surf);
+}
+
+static void VL_SDL3_ScrollSurface(void *surface, int x, int y)
+{
+	SDL_Surface *surf = (SDL_Surface *)surface;
+	int dx = 0, dy = 0, sx = 0, sy = 0;
+	int w = surf->w - CK_Cross_max(x, -x), h = surf->h - CK_Cross_max(y, -y);
+	if (x > 0)
+	{
+		dx = 0;
+		sx = x;
+	}
+	else
+	{
+		dx = -x;
+		sx = 0;
+	}
+	if (y > 0)
+	{
+		dy = 0;
+		sy = y;
+	}
+	else
+	{
+		dy = -y;
+		sy = 0;
+	}
+	VL_SDL3_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
+}
+
+static void VL_SDL3_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+{
+	// TODO: Verify this is a VL_SurfaceUsage_FrontBuffer
+	VL_SDL3_ResizeWindow();
+	SDL_Surface *surf = (SDL_Surface *)surface;
+	SDL_Rect srcr = {(Sint16)scrlX, (Sint16)scrlY, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT};
+	SDL_FRect renderRect = {(float)vl_renderRgn_x, (float)vl_renderRgn_y, (float)vl_renderRgn_w, (float)vl_renderRgn_h};
+	SDL_Rect fullRect = {(Sint16)vl_fullRgn_x, (Sint16)vl_fullRgn_y, vl_fullRgn_w, vl_fullRgn_h};
+	SDL_FRect fullRectF = {(float)vl_fullRgn_x, (float)vl_fullRgn_y, (float)vl_fullRgn_w, (float)vl_fullRgn_h};
+
+	SDL_BlitSurface(surf, &srcr, vl_sdl3_stagingSurface, 0);
+	SDL_LockSurface(vl_sdl3_stagingSurface);
+	SDL_UpdateTexture(vl_sdl3_texture, 0, vl_sdl3_stagingSurface->pixels, vl_sdl3_stagingSurface->pitch);
+	SDL_UnlockSurface(vl_sdl3_stagingSurface);
+	if (vl_sdl3_scaledTarget)
+	{
+		SDL_SetRenderTarget(vl_sdl3_renderer, vl_sdl3_scaledTarget);
+		SDL_SetRenderDrawColor(vl_sdl3_renderer,
+			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][0],
+			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][1],
+			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2],
+			255);
+		SDL_RenderClear(vl_sdl3_renderer);
+		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_texture, 0, &renderRect);
+		SDL_SetRenderTarget(vl_sdl3_renderer, 0);
+		SDL_SetRenderDrawColor(vl_sdl3_renderer, 0, 0, 0, 255);
+		SDL_RenderClear(vl_sdl3_renderer);
+
+		SDL_SetRenderViewport(vl_sdl3_renderer, 0);
+		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_scaledTarget, 0, &fullRectF);
+	}
+	else
+	{
+		SDL_SetRenderTarget(vl_sdl3_renderer, 0);
+		SDL_SetRenderViewport(vl_sdl3_renderer, 0);
+		SDL_SetRenderDrawColor(vl_sdl3_renderer, 0, 0, 0, 255);
+		SDL_RenderClear(vl_sdl3_renderer);
+
+		SDL_SetRenderViewport(vl_sdl3_renderer, 0);
+		SDL_SetRenderViewport(vl_sdl3_renderer, &fullRect);
+		SDL_SetRenderDrawColor(vl_sdl3_renderer,
+			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][0],
+			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][1],
+			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2],
+			255);
+		SDL_RenderFillRect(vl_sdl3_renderer, 0);
+		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_texture, 0, &renderRect);
+
+	}
+
+	SDL_RenderPresent(vl_sdl3_renderer);
+}
+
+static int VL_SDL3_GetActiveBufferId(void *surface)
+{
+	(void)surface;
+	return 0;
+}
+
+static int VL_SDL3_GetNumBuffers(void *surface)
+{
+	(void)surface;
+	return 1;
+}
+
+static void VL_SDL3_SyncBuffers(void *surface)
+{
+	(void)surface;
+}
+
+static void VL_SDL3_UpdateRect(void *surface, int x, int y, int w, int h)
+{
+	(void)surface;
+	(void)x;
+	(void)y;
+	(void)w;
+	(void)h;
+}
+
+static void VL_SDL3_FlushParams()
+{
+	SDL_SetWindowFullscreen(vl_sdl3_window, vl_isFullScreen ? true : false);
+	SDL_SetWindowMinimumSize(vl_sdl3_window, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER / VL_VGA_GFX_WIDTH_SCALEFACTOR, VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER / VL_VGA_GFX_HEIGHT_SCALEFACTOR);
+	SDL_SetRenderVSync(vl_sdl3_renderer, vl_swapInterval);
+	VL_SDL3_ResizeWindow();
+}
+
+static void VL_SDL3_WaitVBLs(int vbls)
+{
+	SDL_Delay(vbls * 1000 / 70);
+}
+
+// Unfortunately, we can't take advantage of designated initializers in C++.
+VL_Backend vl_sdl3_backend =
+	{
+		/*.setVideoMode =*/&VL_SDL3_SetVideoMode,
+		/*.createSurface =*/&VL_SDL3_CreateSurface,
+		/*.destroySurface =*/&VL_SDL3_DestroySurface,
+		/*.getSurfaceMemUse =*/&VL_SDL3_GetSurfaceMemUse,
+		/*.getSurfaceDimensions =*/&VL_SDL3_GetSurfaceDimensions,
+		/*.refreshPaletteAndBorderColor =*/&VL_SDL3_RefreshPaletteAndBorderColor,
+		/*.surfacePGet =*/&VL_SDL3_SurfacePGet,
+		/*.surfaceRect =*/&VL_SDL3_SurfaceRect,
+		/*.surfaceRect_PM =*/&VL_SDL3_SurfaceRect_PM,
+		/*.surfaceToSurface =*/&VL_SDL3_SurfaceToSurface,
+		/*.surfaceToSelf =*/&VL_SDL3_SurfaceToSelf,
+		/*.unmaskedToSurface =*/&VL_SDL3_UnmaskedToSurface,
+		/*.unmaskedToSurface_PM =*/&VL_SDL3_UnmaskedToSurface_PM,
+		/*.maskedToSurface =*/&VL_SDL3_MaskedToSurface,
+		/*.maskedBlitToSurface =*/&VL_SDL3_MaskedBlitToSurface,
+		/*.bitToSurface =*/&VL_SDL3_BitToSurface,
+		/*.bitToSurface_PM =*/&VL_SDL3_BitToSurface_PM,
+		/*.bitXorWithSurface =*/&VL_SDL3_BitXorWithSurface,
+		/*.bitBlitToSurface =*/&VL_SDL3_BitBlitToSurface,
+		/*.bitInvBlitToSurface =*/&VL_SDL3_BitInvBlitToSurface,
+		/*.scrollSurface =*/&VL_SDL3_ScrollSurface,
+		/*.present =*/&VL_SDL3_Present,
+		/*.getActiveBufferId =*/&VL_SDL3_GetActiveBufferId,
+		/*.getNumBuffers =*/&VL_SDL3_GetNumBuffers,
+		/*.syncBuffers =*/&VL_SDL3_SyncBuffers,
+		/*.updateRect =*/&VL_SDL3_UpdateRect,
+		/*.flushParams =*/&VL_SDL3_FlushParams,
+		/*.waitVBLs =*/&VL_SDL3_WaitVBLs,
+};
+
+VL_Backend *VL_Impl_GetBackend()
+{
+	SDL_Init(SDL_INIT_VIDEO);
+	return &vl_sdl3_backend;
+}

--- a/src/id_vl_sdl3gpu.c
+++ b/src/id_vl_sdl3gpu.c
@@ -1,0 +1,719 @@
+/*
+Omnispeak: A Commander Keen Reimplementation
+Copyright (C) 2017 Omnispeak Project Authors
+Commander Keen created by id Software
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "assert.h"
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_gpu.h>
+#include <stdlib.h>
+#include <string.h>
+#include "id_mm.h"
+#include "id_vl.h"
+#include "id_vl_private.h"
+#include "id_us.h"
+#include "ck_cross.h"
+
+#define VL_SDL3GPU_NUM_BUFFERS 2
+
+static uint32_t vert_spv[] =
+#include "id_vl_vk_vert.h"
+	;
+
+static uint32_t frag_spv[] =
+#include "id_vl_vk_frag.h"
+	;
+
+SDL_Window *vl_sdl3_window;
+static int vl_sdl3gpu_framebufferWidth, vl_sdl2vk_framebufferHeight;
+static int vl_sdl3gpu_screenWidth;
+static int vl_sdl3gpu_screenHeight;
+static struct
+{
+	int left, right, top, bottom;
+} vl_sdl3gpu_scaledBorders;
+static int vl_sdl3gpu_screenHorizScaleFactor;
+static int vl_sdl3gpu_screenVertScaleFactor;
+
+static SDL_GPUDevice *vl_sdl3gpu_device;
+
+static SDL_GPUShader *vl_sdl3gpu_vertShader;
+static SDL_GPUShader *vl_sdl3gpu_fragShader;
+
+static SDL_GPUGraphicsPipeline *vl_sdl3gpu_pipeline;
+
+static SDL_GPUSampler *vl_sdl3gpu_sampler;
+
+static int vl_sdl3gpu_integerWidth;
+static int vl_sdl3gpu_integerHeight;
+
+static SDL_GPUTexture *vl_sdl3gpu_integerFramebuffer;
+
+static SDL_GPUPresentMode vl_sdl3gpu_supportedNoVsyncMode;
+
+static bool vl_sdl3gpu_flushSwapchain;
+
+
+static void VL_SDL3GPU_CreateShaders()
+{
+	SDL_GPUShaderCreateInfo vertShaderCreateInfo = {};
+	vertShaderCreateInfo.code = (const Uint8 *)vert_spv;
+	vertShaderCreateInfo.code_size = sizeof(vert_spv);
+	vertShaderCreateInfo.entrypoint = "main";
+	vertShaderCreateInfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
+	vertShaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_VERTEX;
+	vertShaderCreateInfo.num_samplers = 0;
+
+	vl_sdl3gpu_vertShader = SDL_CreateGPUShader(vl_sdl3gpu_device, &vertShaderCreateInfo);
+
+	SDL_GPUShaderCreateInfo fragShaderCreateInfo = {};
+	fragShaderCreateInfo.code = (const Uint8 *)frag_spv;
+	fragShaderCreateInfo.code_size = sizeof(frag_spv);
+	fragShaderCreateInfo.entrypoint = "main";
+	fragShaderCreateInfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
+	fragShaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_FRAGMENT;
+	fragShaderCreateInfo.num_storage_textures = 1;
+	fragShaderCreateInfo.num_uniform_buffers = 1;
+
+	vl_sdl3gpu_fragShader = SDL_CreateGPUShader(vl_sdl3gpu_device, &fragShaderCreateInfo);
+}
+
+static void VL_SDL3GPU_CreatePipeline()
+{
+	SDL_GPUColorTargetDescription colorDesc = {};
+	colorDesc.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;//SDL_GPUGetSwapchainTextureFormat(vl_sdl3gpu_device, vl_sdl3_window);
+	colorDesc.blend_state.enable_blend = true;
+	colorDesc.blend_state.color_write_mask = SDL_GPU_COLORCOMPONENT_R | SDL_GPU_COLORCOMPONENT_G | SDL_GPU_COLORCOMPONENT_B;
+	colorDesc.blend_state.alpha_blend_op = SDL_GPU_BLENDOP_MAX;
+	colorDesc.blend_state.color_blend_op = SDL_GPU_BLENDOP_ADD;
+	colorDesc.blend_state.src_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
+	colorDesc.blend_state.src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
+	colorDesc.blend_state.dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
+	colorDesc.blend_state.dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
+
+
+	SDL_GPUGraphicsPipelineCreateInfo pipelineCreateInfo = {};
+	pipelineCreateInfo.target_info.num_color_targets = 1;
+	pipelineCreateInfo.target_info.color_target_descriptions = &colorDesc;
+
+	pipelineCreateInfo.vertex_input_state.num_vertex_attributes = 0;
+	pipelineCreateInfo.vertex_input_state.num_vertex_buffers = 0;
+
+	pipelineCreateInfo.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLESTRIP;
+	pipelineCreateInfo.vertex_shader = vl_sdl3gpu_vertShader;
+	pipelineCreateInfo.fragment_shader = vl_sdl3gpu_fragShader;
+
+	pipelineCreateInfo.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
+	pipelineCreateInfo.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_NONE;
+
+	pipelineCreateInfo.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+	pipelineCreateInfo.multisample_state.sample_mask = 0xFFFF;
+
+	vl_sdl3gpu_pipeline = SDL_CreateGPUGraphicsPipeline(vl_sdl3gpu_device, &pipelineCreateInfo);
+}
+
+static void VL_SDL3GPU_CreateFramebuffers()
+{
+	SDL_GPUTextureCreateInfo createInfo = { };
+	createInfo.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM; //SDL_GPUGetSwapchainTextureFormat(vl_sdl3gpu_device, vl_sdl3_window);
+	createInfo.width = vl_integerWidth;
+	createInfo.height = vl_integerHeight;
+	createInfo.layer_count_or_depth= 1;
+	createInfo.num_levels = 1;
+	createInfo.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
+	createInfo.sample_count = SDL_GPU_SAMPLECOUNT_1;
+
+	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Creating SDL GPU integer framebuffer of size (%d×%d)\n", vl_integerWidth, vl_integerHeight);
+
+	vl_sdl3gpu_integerFramebuffer = SDL_CreateGPUTexture(vl_sdl3gpu_device, &createInfo);
+
+	SDL_SetGPUTextureName(vl_sdl3gpu_device, vl_sdl3gpu_integerFramebuffer, "integerFramebuffer");
+}
+
+/* TODO (Overscan border):
+ * - If a texture is used for offscreen rendering with scaling applied later,
+ * it's better to have the borders within the texture itself.
+ */
+
+typedef struct VL_SDL3GPU_Surface
+{
+	VL_SurfaceUsage use;
+	SDL_GPUTexture *texture;
+	SDL_GPUTransferBuffer *transferBuffers[VL_SDL3GPU_NUM_BUFFERS];
+	int w, h;
+	int pitch;
+	int activePage;
+	void *data;
+	void *bufferMaps[VL_SDL3GPU_NUM_BUFFERS];
+} VL_SDL3GPU_Surface;
+
+void VL_SDL2GL_SetIcon(SDL_Window *wnd);
+
+void VL_SDL3GPU_FlushParams()
+{
+	SDL_SetWindowFullscreen(vl_sdl3_window, vl_isFullScreen ? SDL_WINDOW_FULLSCREEN : 0);
+	SDL_SetGPUSwapchainParameters(vl_sdl3gpu_device, vl_sdl3_window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, (vl_swapInterval == 0) ? vl_sdl3gpu_supportedNoVsyncMode : SDL_GPU_PRESENTMODE_VSYNC);
+	vl_sdl3gpu_flushSwapchain = true;
+}
+
+
+static void VL_SDL3GPU_SetVideoMode(int mode)
+{
+	if (mode == 0xD)
+	{
+		SDL_Rect desktopBounds;
+		const SDL_DisplayID *displayIDs = SDL_GetDisplays(NULL);
+		if (!SDL_GetDisplayUsableBounds(*displayIDs, &desktopBounds))
+		{
+			CK_Cross_LogMessage(CK_LOG_MSG_ERROR, "Couldn't get usable display bounds to calculate default scale: \"%s\"\n", SDL_GetError());
+		}
+		int scale = VL_CalculateDefaultWindowScale(desktopBounds.w, desktopBounds.h);
+		vl_sdl3_window = SDL_CreateWindow(VL_WINDOW_TITLE,
+			VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale),
+			SDL_WINDOW_RESIZABLE | (vl_isFullScreen ? SDL_WINDOW_FULLSCREEN : 0));
+
+		SDL_SetWindowMinimumSize(vl_sdl3_window, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER / VL_VGA_GFX_WIDTH_SCALEFACTOR, VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER / VL_VGA_GFX_HEIGHT_SCALEFACTOR);
+
+		VL_SDL2GL_SetIcon(vl_sdl3_window);
+
+		SDL_PropertiesID props = SDL_CreateProperties();
+		vl_sdl3gpu_device = SDL_CreateGPUDevice(SDL_GPU_SHADERFORMAT_SPIRV, true, NULL);
+
+		if (!vl_sdl3gpu_device)
+			Quit("Couldn't create SDL GPU device!");
+
+		SDL_ClaimWindowForGPUDevice(vl_sdl3gpu_device, vl_sdl3_window);
+
+		// Prefer MAILBOX to VSYNC if we can.
+		vl_sdl3gpu_supportedNoVsyncMode = SDL_GPU_PRESENTMODE_IMMEDIATE;
+		if (SDL_WindowSupportsGPUPresentMode(vl_sdl3gpu_device, vl_sdl3_window, SDL_GPU_PRESENTMODE_MAILBOX))
+			vl_sdl3gpu_supportedNoVsyncMode = SDL_GPU_PRESENTMODE_MAILBOX;
+
+		VL_SDL3GPU_FlushParams();
+
+		// Compile the shader we use to emulate EGA palettes.
+		VL_SDL3GPU_CreateShaders();
+		VL_SDL3GPU_CreatePipeline();
+
+		VL_CalculateRenderRegions(VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale));
+		VL_SDL3GPU_CreateFramebuffers();
+
+
+		// Hide mouse cursor
+		SDL_HideCursor();
+	}
+	else
+	{
+		SDL_ShowCursor();
+		SDL_ReleaseGPUTexture(vl_sdl3gpu_device, vl_sdl3gpu_integerFramebuffer);
+		SDL_ReleaseGPUGraphicsPipeline(vl_sdl3gpu_device, vl_sdl3gpu_pipeline);
+		SDL_ReleaseGPUShader(vl_sdl3gpu_device, vl_sdl3gpu_fragShader);
+		SDL_ReleaseGPUShader(vl_sdl3gpu_device, vl_sdl3gpu_vertShader);
+		SDL_DestroyGPUDevice(vl_sdl3gpu_device);
+
+		SDL_DestroyWindow(vl_sdl3_window);
+	}
+}
+
+
+static void VL_SDL3GPU_SetSurfacePage(VL_SDL3GPU_Surface *surf, int page)
+{
+	if (surf->use != VL_SurfaceUsage_FrontBuffer)
+		Quit("Tried to set page for a single buffered surface!");
+
+	surf->activePage = page;
+	surf->data = surf->bufferMaps[page];
+}
+
+static void VL_SDL3GPU_SurfaceRect(void *dst_surface, int x, int y, int w, int h, int colour);
+static void *VL_SDL3GPU_CreateSurface(int w, int h, VL_SurfaceUsage usage)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)malloc(sizeof(VL_SDL3GPU_Surface));
+	surf->w = w;
+	surf->h = h;
+	surf->use = usage;
+	if (usage == VL_SurfaceUsage_FrontBuffer)
+	{
+		SDL_GPUTextureCreateInfo texCreateInfo = { };
+		texCreateInfo.format = SDL_GPU_TEXTUREFORMAT_R8_UINT;
+		texCreateInfo.width = w;
+		texCreateInfo.height = h;
+		texCreateInfo.layer_count_or_depth= 1;
+		texCreateInfo.num_levels = 1;
+		texCreateInfo.usage = SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ;
+
+		surf->texture = SDL_CreateGPUTexture(vl_sdl3gpu_device, &texCreateInfo);
+
+		SDL_GPUTransferBufferCreateInfo transferCreateInfo = { };
+		transferCreateInfo.size = w * h;
+		transferCreateInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+
+		for (int i = 0; i < VL_SDL3GPU_NUM_BUFFERS; ++i)
+		{
+			surf->transferBuffers[i] = SDL_CreateGPUTransferBuffer(vl_sdl3gpu_device, &transferCreateInfo);
+			surf->bufferMaps[i] = SDL_MapGPUTransferBuffer(vl_sdl3gpu_device, surf->transferBuffers[i], true);
+		}
+		VL_SDL3GPU_SetSurfacePage(surf, 0);
+		surf->pitch = w;
+	}
+	else
+	{
+		surf->data = malloc(w * h); // 8-bit pal for now
+		surf->pitch = w;
+	}
+	return surf;
+}
+
+static void VL_SDL3GPU_UploadSurface(void *surface)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+
+	SDL_GPUCommandBuffer *uploadCmdBuf = SDL_AcquireGPUCommandBuffer(vl_sdl3gpu_device);
+	SDL_GPUCopyPass *copyPass = SDL_BeginGPUCopyPass(uploadCmdBuf);
+
+	SDL_GPUTextureTransferInfo transferInfo = { 0 };
+	transferInfo.pixels_per_row = surf->pitch;
+	transferInfo.rows_per_layer = surf->h;
+	transferInfo.offset = 0;
+	transferInfo.transfer_buffer = surf->transferBuffers[surf->activePage];
+
+	SDL_GPUTextureRegion transferRegion = { 0 };
+	transferRegion.x = 0;
+	transferRegion.y = 0;
+	transferRegion.z = 0;
+	transferRegion.w = surf->w;
+	transferRegion.h = surf->h;
+	transferRegion.texture = surf->texture;
+	transferRegion.d = 1;
+
+	SDL_UploadToGPUTexture(copyPass, &transferInfo, &transferRegion, true);
+
+	SDL_EndGPUCopyPass(copyPass);
+	SDL_SubmitGPUCommandBuffer(uploadCmdBuf);
+}
+
+static void VL_SDL3GPU_DestroySurface(void *surface)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+	if (surf->use == VL_SurfaceUsage_FrontBuffer)
+	{
+		for (int i = 0; i < VL_SDL3GPU_NUM_BUFFERS; ++i)
+		{
+			SDL_UnmapGPUTransferBuffer(vl_sdl3gpu_device, surf->transferBuffers[i]);
+			SDL_ReleaseGPUTransferBuffer(vl_sdl3gpu_device, surf->transferBuffers[i]);
+			surf->bufferMaps[i] = NULL;
+		}
+		surf->data = 0;
+		SDL_ReleaseGPUTexture(vl_sdl3gpu_device, surf->texture);
+	}
+	else
+	{
+		if (surf->data)
+			free(surf->data);
+	}
+	free(surf);
+}
+
+static long VL_SDL3GPU_GetSurfaceMemUse(void *surface)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+	if (surf->use == VL_SurfaceUsage_FrontBuffer)
+		return surf->w * surf->h * VL_SDL3GPU_NUM_BUFFERS;
+	return surf->w * surf->h;
+}
+
+static void VL_SDL3GPU_GetSurfaceDimensions(void *surface, int *w, int *h)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+	if (w)
+		*w = surf->w;
+	if (h)
+		*h = surf->h;
+}
+
+static void VL_SDL3GPU_SetGLClearColorFromBorder(void)
+{
+	/*glClearColor((GLclampf)VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][0]/255,
+		     (GLclampf)VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][1]/255,
+		     (GLclampf)VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2]/255,
+		     1.0f
+	);*/
+}
+
+static void VL_SDL3GPU_RefreshPaletteAndBorderColor(void *screen)
+{
+	static uint8_t sdl3gpu_palette[16][3];
+
+	for (int i = 0; i < 16; i++)
+	{
+		memcpy(sdl3gpu_palette[i], VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]], 3);
+	}
+	// Load the palette into a texture.
+
+	VL_SDL3GPU_SetGLClearColorFromBorder();
+}
+
+static int VL_SDL3GPU_SurfacePGet(void *surface, int x, int y)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+	return ((uint8_t *)surf->data)[y * surf->pitch + x];
+}
+
+static void VL_SDL3GPU_SurfaceRect(void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	for (int _y = y; _y < y + h; ++_y)
+	{
+		memset(((uint8_t *)surf->data) + _y * surf->pitch + x, colour, w);
+	}
+}
+
+static void VL_SDL3GPU_SurfaceRect_PM(void *dst_surface, int x, int y, int w, int h, int colour, int mapmask)
+{
+	mapmask &= 0xF;
+	colour &= mapmask;
+
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	for (int _y = y; _y < y + h; ++_y)
+	{
+		for (int _x = x; _x < x + w; ++_x)
+		{
+			uint8_t *p = ((uint8_t *)surf->data) + _y * surf->pitch + _x;
+			*p &= ~mapmask;
+			*p |= colour;
+		}
+	}
+}
+
+static void VL_SDL3GPU_SurfaceToSurface(void *src_surface, void *dst_surface, int x, int y, int sx, int sy, int sw, int sh)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)src_surface;
+	VL_SDL3GPU_Surface *dest = (VL_SDL3GPU_Surface *)dst_surface;
+	for (int _y = sy; _y < sy + sh; ++_y)
+	{
+		memcpy(((uint8_t *)dest->data) + (_y - sy + y) * dest->pitch + x, ((uint8_t *)surf->data) + _y * surf->pitch + sx, sw);
+	}
+}
+
+static void VL_SDL3GPU_SurfaceToSelf(void *surface, int x, int y, int sx, int sy, int sw, int sh)
+{
+	VL_SDL3GPU_Surface *srf = (VL_SDL3GPU_Surface *)surface;
+	bool directionX = sx > x;
+	bool directionY = sy > y;
+
+	if (directionY)
+	{
+		for (int yi = 0; yi < sh; ++yi)
+		{
+			memmove(((uint8_t *)srf->data) + ((yi + y) * srf->pitch + x), ((uint8_t *)srf->data) + ((sy + yi) * srf->pitch + sx), sw);
+		}
+	}
+	else
+	{
+		for (int yi = sh - 1; yi >= 0; --yi)
+		{
+			memmove(((uint8_t *)srf->data) + ((yi + y) * srf->pitch + x), ((uint8_t *)srf->data) + ((sy + yi) * srf->pitch + sx), sw);
+		}
+	}
+}
+
+static void VL_SDL3GPU_UnmaskedToSurface(void *src, void *dst_surface, int x, int y, int w, int h)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_UnmaskedToPAL8(src, surf->data, x, y, surf->pitch, w, h);
+}
+
+static void VL_SDL3GPU_UnmaskedToSurface_PM(void *src, void *dst_surface, int x, int y, int w, int h, int mapmask)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_UnmaskedToPAL8_PM(src, surf->data, x, y, surf->pitch, w, h, mapmask);
+}
+
+static void VL_SDL3GPU_MaskedToSurface(void *src, void *dst_surface, int x, int y, int w, int h)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_MaskedToPAL8(src, surf->data, x, y, surf->pitch, w, h);
+}
+
+static void VL_SDL3GPU_MaskedBlitToSurface(void *src, void *dst_surface, int x, int y, int w, int h)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_MaskedBlitClipToPAL8(src, surf->data, x, y, surf->pitch, w, h, surf->w, surf->h);
+}
+
+static void VL_SDL3GPU_BitToSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_1bppToPAL8(src, surf->data, x, y, surf->pitch, w, h, colour);
+}
+
+static void VL_SDL3GPU_BitToSurface_PM(void *src, void *dst_surface, int x, int y, int w, int h, int colour, int mapmask)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_1bppToPAL8_PM(src, surf->data, x, y, surf->pitch, w, h, colour, mapmask);
+}
+
+static void VL_SDL3GPU_BitXorWithSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_1bppXorWithPAL8(src, surf->data, x, y, surf->pitch, w, h, colour);
+}
+
+static void VL_SDL3GPU_BitBlitToSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_1bppBlitToPAL8(src, surf->data, x, y, surf->pitch, w, h, colour);
+}
+
+static void VL_SDL3GPU_BitInvBlitToSurface(void *src, void *dst_surface, int x, int y, int w, int h, int colour)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)dst_surface;
+	VL_1bppInvBlitClipToPAL8(src, surf->data, x, y, surf->pitch, w, h, surf->w, surf->h, colour);
+}
+
+static void VL_SDL3GPU_ScrollSurface(void *surface, int x, int y)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+	int dx = 0, dy = 0, sx = 0, sy = 0;
+	int w = surf->w - CK_Cross_max(x, -x), h = surf->h - CK_Cross_max(y, -y);
+	if (x > 0)
+	{
+		dx = 0;
+		sx = x;
+	}
+	else
+	{
+		dx = -x;
+		sx = 0;
+	}
+	if (y > 0)
+	{
+		dy = 0;
+		sy = y;
+	}
+	else
+	{
+		dy = -y;
+		sy = 0;
+	}
+
+	int oldPage = surf->activePage;
+	if (surf->use == VL_SurfaceUsage_FrontBuffer)
+	{
+		for (int i = 0; i < VL_SDL3GPU_NUM_BUFFERS; ++i)
+		{
+			VL_SDL3GPU_SetSurfacePage(surf, i);
+			VL_SDL3GPU_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
+		}
+		VL_SDL3GPU_SetSurfacePage(surf, oldPage);
+	}
+	else
+
+	VL_SDL3GPU_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
+}
+
+static void VL_SDL3GPU_BindTexture(VL_SDL3GPU_Surface *surf, SDL_GPURenderPass *renderPass)
+{
+	SDL_GPUTextureSamplerBinding binding = {};
+	binding.texture = surf->texture;
+	binding.sampler = vl_sdl3gpu_sampler;
+
+	SDL_BindGPUFragmentStorageTextures(renderPass, 0, &surf->texture, 1);
+	//SDL_BindGPUFragmentSamplers(renderPass, 0, &binding, 1);
+}
+
+static void VL_SDL3GPU_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+{
+	SDL_GPUTexture *swapchainTexture;
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+
+	uint32_t newW, newH;
+	VL_SDL3GPU_UploadSurface(surface);
+	SDL_GPUCommandBuffer *renderBuffer = SDL_AcquireGPUCommandBuffer(vl_sdl3gpu_device);
+	if (!SDL_AcquireGPUSwapchainTexture(renderBuffer, vl_sdl3_window, &swapchainTexture, &newW, &newH) || !swapchainTexture)
+	{
+		SDL_SubmitGPUCommandBuffer(renderBuffer);
+		return;
+	}
+
+	if (newW != vl_sdl3gpu_screenWidth || newH != vl_sdl3gpu_screenHeight || vl_sdl3gpu_flushSwapchain)
+	{
+		CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Resizing swapchain: %d -> %d, %d -> %d\n", vl_sdl3gpu_screenWidth, vl_sdl3gpu_screenHeight, newW, newH);
+		vl_sdl3gpu_screenWidth = newW;
+		vl_sdl3gpu_screenHeight = newH;
+		VL_CalculateRenderRegions(newW, newH);
+		SDL_ReleaseGPUTexture(vl_sdl3gpu_device, vl_sdl3gpu_integerFramebuffer);
+		VL_SDL3GPU_CreateFramebuffers();
+		vl_sdl3gpu_flushSwapchain = false;
+	}
+
+	SDL_GPUColorTargetInfo innerAttachmentInfo = {};
+	innerAttachmentInfo.clear_color.r = VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][0] / 255.f;
+	innerAttachmentInfo.clear_color.g = VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][1] / 255.f;
+	innerAttachmentInfo.clear_color.b = VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2] / 255.f;
+	innerAttachmentInfo.clear_color.a = 1.f;
+	innerAttachmentInfo.cycle = true;
+	innerAttachmentInfo.load_op = SDL_GPU_LOADOP_CLEAR;
+	innerAttachmentInfo.store_op = SDL_GPU_STOREOP_STORE;
+	innerAttachmentInfo.texture = vl_sdl3gpu_integerFramebuffer;
+
+	SDL_GPURenderPass *innerPass = SDL_BeginGPURenderPass(renderBuffer, &innerAttachmentInfo, 1, NULL);
+
+	SDL_BindGPUGraphicsPipeline(innerPass, vl_sdl3gpu_pipeline);
+	VL_SDL3GPU_BindTexture((VL_SDL3GPU_Surface *)surface, innerPass);
+
+	SDL_GPUViewport renderRgn;
+	renderRgn.x = vl_renderRgn_x;
+	renderRgn.y = vl_renderRgn_y;
+	renderRgn.w = vl_renderRgn_w;
+	renderRgn.h = vl_renderRgn_h;
+	renderRgn.max_depth = 1.f;
+	renderRgn.min_depth= 0.f;
+
+	SDL_SetGPUViewport(innerPass, &renderRgn);
+	//TODO: Do we need to set a scissor rect as well?
+
+	float data[4 * 17];
+	data[0] = scrlX;
+	data[1] = scrlY;
+	for (int i = 0; i < 16; ++i)
+	{
+		data[4 + 4 * i] = (float)VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][0] / 255.0;
+		data[5 + 4 * i] = (float)VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][1] / 255.0;
+		data[6 + 4 * i] = (float)VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][2] / 255.0;
+		data[7 + 4 * i] = 255.0;
+	}
+	SDL_PushGPUFragmentUniformData(renderBuffer, 0, data, sizeof(float) * 4 * 17);
+
+	SDL_DrawGPUPrimitives(innerPass, 4, 1, 0, 0);
+
+	SDL_EndGPURenderPass(innerPass);
+
+	SDL_GPUBlitInfo blitInfo = {};
+	blitInfo.source.texture = vl_sdl3gpu_integerFramebuffer;
+	blitInfo.source.x = 0;
+	blitInfo.source.y = 0;
+	blitInfo.source.w = vl_integerWidth;
+	blitInfo.source.h = vl_integerHeight;
+
+	blitInfo.destination.texture = swapchainTexture;
+	blitInfo.destination.x = vl_fullRgn_x;
+	blitInfo.destination.y = vl_fullRgn_y;
+	blitInfo.destination.w = vl_fullRgn_w;
+	blitInfo.destination.h = vl_fullRgn_h;
+	blitInfo.load_op = SDL_GPU_LOADOP_CLEAR;
+	blitInfo.clear_color.r = 0.f;
+	blitInfo.clear_color.g = 0.f;
+	blitInfo.clear_color.b = 0.f;
+	blitInfo.clear_color.a = 1.f;
+	blitInfo.cycle = true;
+	blitInfo.filter = SDL_GPU_FILTER_LINEAR;
+
+	//TODO: We need a way to ensure the framebuffer is cleared first?
+	SDL_BlitGPUTexture(renderBuffer, &blitInfo);
+
+	SDL_SubmitGPUCommandBuffer(renderBuffer);
+
+	if (!singleBuffered && surf->use == VL_SurfaceUsage_FrontBuffer)
+		VL_SDL3GPU_SetSurfacePage(surf, (surf->activePage + 1) % VL_SDL3GPU_NUM_BUFFERS);
+
+}
+
+static int VL_SDL3GPU_GetActiveBufferId(void *surface)
+{
+	VL_SDL3GPU_Surface *srf = (VL_SDL3GPU_Surface*)surface;
+	return srf->activePage;
+}
+
+static int VL_SDL3GPU_GetNumBuffers(void *surface)
+{
+	(void)surface;
+	return VL_SDL3GPU_NUM_BUFFERS;
+}
+
+static void VL_SDL3GPU_SyncBuffers(void *surface)
+{
+	VL_SDL3GPU_Surface *srf = (VL_SDL3GPU_Surface*)surface;
+	// Get the last fully-rendered page.
+	int prevPage = (srf->activePage + VL_SDL3GPU_NUM_BUFFERS - 1) % VL_SDL3GPU_NUM_BUFFERS;
+
+	for (int page = 0; page < VL_SDL3GPU_NUM_BUFFERS; ++page)
+	{
+		if (page == prevPage)
+			continue;
+		memcpy(srf->bufferMaps[page], srf->bufferMaps[prevPage], srf->w * srf->h);
+	}
+}
+
+static void VL_SDL3GPU_UpdateRect(void *surface, int x, int y, int w, int h)
+{
+	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
+	for (int page = 0; page < VL_SDL3GPU_NUM_BUFFERS; ++page)
+	{
+		if (page == surf->activePage)
+			continue;
+		for (int _y = y; _y < y + h; ++_y)
+		{
+			memcpy(((uint8_t *)surf->bufferMaps[page]) + (_y) * surf->w + x, ((uint8_t *)surf->data) + _y * surf->w + x, w);
+		}
+	}
+}
+
+static void VL_SDL3GPU_WaitVBLs(int vbls)
+{
+	SDL_Delay(vbls * 1000 / 70);
+}
+
+// Unfortunately, we can't take advantage of designated initializers in C++.
+VL_Backend vl_sdl3gpu_backend =
+	{
+		/*.setVideoMode =*/&VL_SDL3GPU_SetVideoMode,
+		/*.createSurface =*/&VL_SDL3GPU_CreateSurface,
+		/*.destroySurface =*/&VL_SDL3GPU_DestroySurface,
+		/*.getSurfaceMemUse =*/&VL_SDL3GPU_GetSurfaceMemUse,
+		/*.getSurfaceDimensions =*/&VL_SDL3GPU_GetSurfaceDimensions,
+		/*.refreshPaletteAndBorderColor =*/&VL_SDL3GPU_RefreshPaletteAndBorderColor,
+		/*.surfacePGet =*/&VL_SDL3GPU_SurfacePGet,
+		/*.surfaceRect =*/&VL_SDL3GPU_SurfaceRect,
+		/*.surfaceRect_PM =*/&VL_SDL3GPU_SurfaceRect_PM,
+		/*.surfaceToSurface =*/&VL_SDL3GPU_SurfaceToSurface,
+		/*.surfaceToSelf =*/&VL_SDL3GPU_SurfaceToSelf,
+		/*.unmaskedToSurface =*/&VL_SDL3GPU_UnmaskedToSurface,
+		/*.unmaskedToSurface_PM =*/&VL_SDL3GPU_UnmaskedToSurface_PM,
+		/*.maskedToSurface =*/&VL_SDL3GPU_MaskedToSurface,
+		/*.maskedBlitToSurface =*/&VL_SDL3GPU_MaskedBlitToSurface,
+		/*.bitToSurface =*/&VL_SDL3GPU_BitToSurface,
+		/*.bitToSurface_PM =*/&VL_SDL3GPU_BitToSurface_PM,
+		/*.bitXorWithSurface =*/&VL_SDL3GPU_BitXorWithSurface,
+		/*.bitBlitToSurface =*/&VL_SDL3GPU_BitBlitToSurface,
+		/*.bitInvBlitToSurface =*/&VL_SDL3GPU_BitInvBlitToSurface,
+		/*.scrollSurface =*/&VL_SDL3GPU_ScrollSurface,
+		/*.present =*/&VL_SDL3GPU_Present,
+		/*.getActiveBufferId =*/&VL_SDL3GPU_GetActiveBufferId,
+		/*.getNumBuffers =*/&VL_SDL3GPU_GetNumBuffers,
+		/*.syncBuffers =*/&VL_SDL3GPU_SyncBuffers,
+		/*.updateRect =*/&VL_SDL3GPU_UpdateRect,
+		/*.flushParams =*/&VL_SDL3GPU_FlushParams,
+		/*.waitVBLs =*/&VL_SDL3GPU_WaitVBLs
+	};
+
+VL_Backend *VL_Impl_GetBackend()
+{
+	SDL_Init(SDL_INIT_VIDEO);
+	return &vl_sdl3gpu_backend;
+}

--- a/src/id_vl_vk_shader.frag
+++ b/src/id_vl_vk_shader.frag
@@ -3,16 +3,16 @@
 
 layout(location = 0) out vec4 outColour;
 layout(location = 0) in vec2 texCoord;
-layout(binding = 0) uniform FragUniforms
+layout(set = 3, binding = 0) uniform FragUniforms
 {
 	vec2 texOffs;
 	vec4 pal[16];
 } ubo;
-layout(set = 1, binding = 1) uniform usampler2D screen;
+layout(set = 2, binding = 0, r8ui) uniform readonly  uimage2D screen;
 
 void main() {
 	ivec2 fixedTexCoord = ivec2(texCoord + ubo.texOffs);
-	uint palIndex = texelFetch(screen, fixedTexCoord, 0).r;
+	uint palIndex = imageLoad(screen, fixedTexCoord).r;
 	outColour = ubo.pal[palIndex];
 }
 

--- a/src/id_vl_vk_shader.vert
+++ b/src/id_vl_vk_shader.vert
@@ -8,10 +8,10 @@ out gl_PerVertex {
 layout(location=0) out vec2 texCoord;
 
 vec2 positions[4] = vec2[](
-    vec2(-1.0, -1.0),
-    vec2(1.0, -1.0),
     vec2(-1.0, 1.0),
-    vec2(1.0, 1.0)
+    vec2(1.0, 1.0),
+    vec2(-1.0, -1.0),
+    vec2(1.0, -1.0)
 );
 
 vec2 texCoords[4] = vec2[](


### PR DESCRIPTION
Add VL, SD, and IN backends for SDL3. We do this instead of using the combined SDL1/2 backends for SD and IN, as so many functions have been renamed. This does present some problems, as otherwise they share a lot of code, so one will likely end up outdated.

Otherwise, this is still incomplete:
- No CMake support.
- Sound is broken with SDL_QueueAudio
- Graphics is probably broken on big-endian.
- The pkg-config bits in the makefile are a bit ugly.
- One day we'll want an SDL3_gpu based VL backend, but the renderer is good for now.