### PR TITLE
id_ca: Fix build in big endian systems

### DIFF
--- a/src/id_ca.c
+++ b/src/id_ca.c
@@ -742,7 +742,7 @@ void CA_CacheGrChunk(int chunk)
 			spriteTable[i].shifts = CK_Cross_SwapLE16(spriteTable[i].shifts);
 		}
 	}
-	else if (chunk >= FON_MAINFONT && chunk <= /*FON_WATCHFONT*/ FON_MAINFONT + 2)
+	else if (chunk >= CK_CHUNKNUM(FON_MAINFONT) && chunk <= /*FON_WATCHFONT*/ CK_CHUNKNUM(FON_MAINFONT) + 2)
 	{
 		VH_Font *font = (VH_Font *)ca_graphChunks[chunk];
 		font->height = CK_Cross_SwapLE16(font->height);
@@ -751,7 +751,7 @@ void CA_CacheGrChunk(int chunk)
 			font->location[i] = CK_Cross_SwapLE16(font->location[i]);
 		}
 	}
-	else if (chunk >= EXTERN_COMMANDER && chunk <= EXTERN_KEEN)
+	else if (chunk >= CK_CHUNKNUM(EXTERN_COMMANDER) && chunk <= CK_CHUNKNUM(EXTERN_KEEN))
 	{
 		introbmptype *intro = (introbmptype *)ca_graphChunks[chunk];
 		intro->height = CK_Cross_SwapLE16(intro->height);


### PR DESCRIPTION
These variables look to be left over from the commit https://github.com/sulix/omnispeak/commit/5ac988e04886177edb76800958f0350d89059e01

Easily missed as its wrapped in a `CK_CROSS_IS_BIGENDIAN` ifdef. I was getting this error.

```
id_ca.c:747:27: error: 'FON_MAINFONT' undeclared (first use in this function)
  747 |         else if (chunk >= FON_MAINFONT && chunk <= /*FON_WATCHFONT*/ FON_MAINFONT + 2)
      |                           ^~~~~~~~~~~~
id_ca.c:756:27: error: 'EXTERN_COMMANDER' undeclared (first use in this function)
  756 |         else if (chunk >= EXTERN_COMMANDER && chunk <= EXTERN_KEEN)
      |                           ^~~~~~~~~~~~~~~~
d_ca.c:756:56: error: 'EXTERN_KEEN' undeclared (first use in this function)
  756 |         else if (chunk >= EXTERN_COMMANDER && chunk <= EXTERN_KEEN)
      |                                                        ^~~~~~~~~~~
```
