### PR TITLE
id_ca: Use filenames from EPISODE.CKx

### DIFF
--- a/data/keen4/EPISODE.CK4
+++ b/data/keen4/EPISODE.CK4
@@ -3,6 +3,24 @@
 #
 
 # Episode variables
+
+# Graphics files
+%string ca_gfxInfoFile "GFXINFOE.CK4"
+%string ca_graphDict "EGADICT.CK4"
+%string ca_graphHead "EGAHEAD.CK4"
+%string ca_graphFile "EGAGRAPH.CK4"
+
+# Sound Files
+%string ca_audioInfoFile "AUDINFOE.CK4"
+%string ca_audioHead "AUDIOHHD.CK4"
+%string ca_audioDict "AUDIODCT.CK4"
+%string ca_audioFile "AUDIO.CK4"
+
+# Level Files
+%string ca_mapFile "GAMEMAPS.CK4"
+%string ca_mapHead "MAPHEAD.CK4"
+%string ca_tileInfo "TILEINFO.CK4"
+
 %int CK_activeLimit 4
 %int CK_highScoreLevel 19
 %int CK_highScoreTopMargin 0x33

--- a/data/keen5/EPISODE.CK5
+++ b/data/keen5/EPISODE.CK5
@@ -3,6 +3,24 @@
 #
 
 # Episode variables
+
+# Graphics files
+%string ca_gfxInfoFile "GFXINFOE.CK5"
+%string ca_graphDict "EGADICT.CK5"
+%string ca_graphHead "EGAHEAD.CK5"
+%string ca_graphFile "EGAGRAPH.CK5"
+
+# Sound Files
+%string ca_audioInfoFile "AUDINFOE.CK5"
+%string ca_audioHead "AUDIOHHD.CK5"
+%string ca_audioDict "AUDIODCT.CK5"
+%string ca_audioFile "AUDIO.CK5"
+
+# Level Files
+%string ca_mapFile "GAMEMAPS.CK5"
+%string ca_mapHead "MAPHEAD.CK5"
+%string ca_tileInfo "TILEINFO.CK5"
+
 %int CK_activeLimit 6
 %int CK_highScoreLevel 15
 %int CK_highScoreTopMargin 0x23

--- a/data/keen6e14/EPISODE.CK6
+++ b/data/keen6e14/EPISODE.CK6
@@ -3,6 +3,24 @@
 #
 
 # Episode variables
+
+# Graphics files
+%string ca_gfxInfoFile "GFXINFOE.CK6"
+%string ca_graphDict "EGADICT.CK6"
+%string ca_graphHead "EGAHEAD.CK6"
+%string ca_graphFile "EGAGRAPH.CK6"
+
+# Sound Files
+%string ca_audioInfoFile "AUDINFOE.CK6"
+%string ca_audioHead "AUDIOHHD.CK6"
+%string ca_audioDict "AUDIODCT.CK6"
+%string ca_audioFile "AUDIO.CK6"
+
+# Level Files
+%string ca_mapFile "GAMEMAPS.CK6"
+%string ca_mapHead "MAPHEAD.CK6"
+%string ca_tileInfo "TILEINFO.CK6"
+
 %int CK_activeLimit 4
 %int CK_highScoreLevel 18
 %int CK_highScoreTopMargin 0x33

--- a/data/keen6e15/EPISODE.CK6
+++ b/data/keen6e15/EPISODE.CK6
@@ -3,6 +3,24 @@
 #
 
 # Episode variables
+
+# Graphics files
+%string ca_gfxInfoFile "GFXINFOE.CK6"
+%string ca_graphDict "EGADICT.CK6"
+%string ca_graphHead "EGAHEAD.CK6"
+%string ca_graphFile "EGAGRAPH.CK6"
+
+# Sound Files
+%string ca_audioInfoFile "AUDINFOE.CK6"
+%string ca_audioHead "AUDIOHHD.CK6"
+%string ca_audioDict "AUDIODCT.CK6"
+%string ca_audioFile "AUDIO.CK6"
+
+# Level Files
+%string ca_mapFile "GAMEMAPS.CK6"
+%string ca_mapHead "MAPHEAD.CK6"
+%string ca_tileInfo "TILEINFO.CK6"
+
 %int CK_activeLimit 4
 %int CK_highScoreLevel 18
 %int CK_highScoreTopMargin 0x33

--- a/src/ck_act.c
+++ b/src/ck_act.c
@@ -660,5 +660,5 @@ void CK_VAR_LoadVars(const char *filename)
 	while (CK_VAR_ParseVar(&parserstate))
 		numVarsParsed++;
 
-	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Parsed %d vars from \"%s\" over %d lines (%d actions created).\n", numVarsParsed, FS_AdjustExtension(filename), parserstate.linecount, ck_actionsUsed);
+	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Parsed %d vars from \"%s\" over %d lines (%d actions created).\n", numVarsParsed, filename, parserstate.linecount, ck_actionsUsed);
 }

--- a/src/ck_act.h
+++ b/src/ck_act.h
@@ -68,6 +68,7 @@ typedef int16_t chunk_id_t;
 #define CK_INTELEMENT(name, i) (CK_INTARRAY(name)[i])
 #define CK_STRINGARRAY(name) STRARRAY_ ## name
 #define CK_STRINGELEMENT(name, i) (CK_STRINGARRAY(name)[i])
+#define CK_FILENAME(name, def) STRINGS_ ## name
 #else
 #define CK_INT(name, default) CK_VAR_GetInt(#name, default)
 #define CK_CHUNKNUM(name) CK_VAR_GetInt(#name, 0)
@@ -80,6 +81,7 @@ typedef const char *chunk_id_t;
 #define CK_INTELEMENT(name, i) CK_VAR_GetIntArrayElement(#name, i)
 #define CK_STRINGARRAY(name) CK_VAR_GetStringArray(#name)
 #define CK_STRINGELEMENT(name, i) CK_VAR_GetStringArrayElement(#name, i)
+#define CK_FILENAME(name, def) CK_VAR_GetString(#name, FS_AdjustExtension(def))
 #endif
 
 

--- a/src/ck_main.c
+++ b/src/ck_main.c
@@ -130,7 +130,7 @@ void CK_InitGame()
 
 
 	CK_VAR_Startup();
-	CK_VAR_LoadVars("EPISODE.EXT");
+	CK_VAR_LoadVars(FS_AdjustExtension("EPISODE.EXT"));
 
 	// Load the core datafiles
 	CA_Startup();
@@ -615,7 +615,7 @@ int main(int argc, char *argv[])
 
 	if (!ck_currentEpisode->isPresent())
 	{
-		Quit("Couldn't find game data files!");
+	//	Quit("Couldn't find game data files!");
 	}
 
 #ifdef CK_ENABLE_PLAYLOOP_DUMPER

--- a/src/ck_quit.c
+++ b/src/ck_quit.c
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include "id_heads.h"
 #include "ck_act.h"
 #include "ck_cross.h"
@@ -57,4 +58,14 @@ void Quit(const char *msg)
 #endif
 		exit(-1);
 	}
+}
+
+void QuitF(const char *msg, ...)
+{
+	char msg_buf[512];
+	va_list args;
+	va_start(args, msg);
+	vsnprintf(msg_buf, sizeof(msg_buf), msg, args);
+	va_end(args);
+	Quit(msg_buf);
 }

--- a/src/id_ca.c
+++ b/src/id_ca.c
@@ -1102,6 +1102,8 @@ void CA_CacheMap(int mapIndex)
 		//Make sure we don't purge it accidentally.
 		MM_SetPurge((void **)(&CA_MapHeaders[mapIndex]), 0);
 	}
+	
+	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "CA_CacheMap: Loading map %d (\"%s\")\n", mapIndex, CA_MapHeaders[mapIndex]->name);
 
 	int planeSize = CA_MapHeaders[mapIndex]->width * CA_MapHeaders[mapIndex]->height * 2;
 

--- a/src/id_ca.h
+++ b/src/id_ca.h
@@ -48,7 +48,6 @@ void CA_LoadAllSounds(void);
 // -- File IO --
 
 size_t CA_GetFileSize(char *filename);
-char *CAL_AdjustExtension(const char *filename);
 bool CA_FarWrite(int handle, uint8_t *source, int length);
 bool CA_ReadFile(const char *filename, void *offset);
 bool CA_SafeReadFile(const char *filename, void *offset, int bufLength);

--- a/src/id_us.h
+++ b/src/id_us.h
@@ -45,6 +45,7 @@ typedef struct
 
 // In ck_quit.c, as it may be customized by individual games.
 void Quit(const char *msg) _NORETURN;
+void QuitF(const char *msg, ...) _NORETURN CK_PRINTF_FORMAT(1, 2);
 
 // id_us_1.c:
 // Parameter Checking


### PR DESCRIPTION
@NY00123 Would something like this work as a replacement for #63? (Obviously there are a few tidy-ups, support for a few other files which would be required, but if the concept's sound, we can just change ``ca_mapFile`` et al.)

Instead of hardcoding the filenames for the various files needed by ID_CA (i.e., audio, graphics, and level files), load them from variables in EPISODE.CKx.

This gets rid of some AdjustExtension() calls, as well as making it easier for mods to use the different filenames produced by different tools (e.g. EDITMAPS, MAPTEMP, etc).

Note that this doesn't do anything fancy with the episode detection or anything yet, nor does it cover other files, outside ID_CA.