### PR TITLE
ck6_obj2: Fix turning of Flect as a consequence of changing side with relation to Keen

### DIFF
--- a/src/ck6_obj2.c
+++ b/src/ck6_obj2.c
@@ -611,7 +611,7 @@ void CK6_FlectWalk(CK_object *obj)
 {
 	if (ck_keenObj->posX < obj->posX && obj->xDirection == IN_motion_Right)
 	{
-		if (obj->xDirection == IN_motion_Left)
+//		if (obj->xDirection != IN_motion_Left) // Always true
 			obj->currentAction = CK_ACTION(CK6_ACT_FlectTurn1);
 
 		obj->xDirection = IN_motion_Left;
@@ -619,7 +619,7 @@ void CK6_FlectWalk(CK_object *obj)
 
 	if (ck_keenObj->posX > obj->posX && obj->xDirection == IN_motion_Left)
 	{
-		if (obj->xDirection == IN_motion_Right)
+//		if (obj->xDirection != IN_motion_Right) // Always true
 			obj->currentAction = CK_ACTION(CK6_ACT_FlectTurn1);
 
 		obj->xDirection = IN_motion_Right;


### PR DESCRIPTION
The Flect should look straight forward (including its teeth) first, but that wouldn't occur in practice. The corrected inner xDirection checks are redundant, but were apparently still in the original code.

This can be reproduced in another AAMBA demo sequence, the last one to be played (DEMO3.CK6).