### PR TITLE
Support different screen resolutions (widescreen; fixes #36, #69)

### DIFF
--- a/data/keen4/EPISODE.CK4
+++ b/data/keen4/EPISODE.CK4
@@ -30,6 +30,11 @@
 %string us_saveFile "SAVEGAM?.CK4" # Use a '?' for the savegame number.
 %string ck_demoFileName "DEMO?.CK4" # For F10+D, use '?' for the demo number.
 
+# This is the screen resolution used for DEMO playback, as well as the default
+# used.
+%int rf_demoScreenWidth 320
+%int rf_demoScreenHeight 200
+
 %int CK_activeLimit 4
 %int CK_highScoreLevel 19
 %int CK_highScoreTopMargin 0x33

--- a/data/keen5/EPISODE.CK5
+++ b/data/keen5/EPISODE.CK5
@@ -30,6 +30,11 @@
 %string us_saveFile "SAVEGAM?.CK5" # Use a '?' for the savegame number.
 %string ck_demoFileName "DEMO?.CK5" # For F10+D, use '?' for the demo number.
 
+# This is the screen resolution used for DEMO playback, as well as the default
+# used.
+%int rf_demoScreenWidth 320
+%int rf_demoScreenHeight 200
+
 %int CK_activeLimit 6
 %int CK_highScoreLevel 15
 %int CK_highScoreTopMargin 0x23

--- a/data/keen6e14/EPISODE.CK6
+++ b/data/keen6e14/EPISODE.CK6
@@ -30,6 +30,11 @@
 %string us_saveFile "SAVEGAM?.CK6" # Use a '?' for the savegame number.
 %string ck_demoFileName "DEMO?.CK6" # For F10+D, use '?' for the demo number.
 
+# This is the screen resolution used for DEMO playback, as well as the default
+# used.
+%int rf_demoScreenWidth 320
+%int rf_demoScreenHeight 200
+
 %int CK_activeLimit 4
 %int CK_highScoreLevel 18
 %int CK_highScoreTopMargin 0x33

--- a/data/keen6e15/EPISODE.CK6
+++ b/data/keen6e15/EPISODE.CK6
@@ -30,6 +30,11 @@
 %string us_saveFile "SAVEGAM?.CK6" # Use a '?' for the savegame number.
 %string ck_demoFileName "DEMO?.CK6" # For F10+D, use '?' for the demo number.
 
+# This is the screen resolution used for DEMO playback, as well as the default
+# used.
+%int rf_demoScreenWidth 320
+%int rf_demoScreenHeight 200
+
 %int CK_activeLimit 4
 %int CK_highScoreLevel 18
 %int CK_highScoreTopMargin 0x33

--- a/src/ck_def.h
+++ b/src/ck_def.h
@@ -479,6 +479,7 @@ void CK_OBJ_SetupFunctions();
 /* ck_main.c */
 extern bool ck_storeDemo;
 
+void CK_ResizeStatusBuffers();
 void CK_MeasureMultiline(const char *str, uint16_t *w, uint16_t *h);
 void CK_ShutdownID();
 

--- a/src/ck_game.c
+++ b/src/ck_game.c
@@ -666,6 +666,14 @@ void CK_LoadLevel(bool doCache, bool silent)
 		RF_Resize(CFG_GetConfigInt("screenWidth", defaultWidth), CFG_GetConfigInt("screenHeight", defaultHeight));
 	}
 	CK_ResizeStatusBuffers();
+
+	// Determine and set the map garbage emulation.
+	// (If our screen resolution is higher than the levels support, we can end up
+	// seeing outside the level bounds, which often will crash on invalid tiles.)
+	if (RF_BUFFER_WIDTH_TILES > 21 || RF_BUFFER_HEIGHT_TILES > 14)
+		ca_emulateMapGarbage = CFG_GetConfigBool("ca_emulateMapGarbage", false);
+	else
+		ca_emulateMapGarbage = CFG_GetConfigBool("ca_emulateMapGarbage", true);
 }
 
 // Cache Box Routines

--- a/src/ck_game.c
+++ b/src/ck_game.c
@@ -647,6 +647,25 @@ void CK_LoadLevel(bool doCache, bool silent)
 	// CA_CacheMarks(0);
 	if (doCache && !silent)
 		CK_BeginFadeDrawing();
+
+	// We need to resize RF _here_ for a number of reasons:
+	// - It's safe to do so, as — despite our already having called RF_NewMap() —
+	//   we've not yet drawn anything, or done anything dependent on the map
+	//   size (like fill animated tile lists).
+	// - The game needs to fade out the old screen (see above) with the old
+	//   screen contents (and hence size) still intact, so we can't do it
+	//   before now.
+	// - The fade in is deferred, so we are resizing before anything is seen
+	//   (and indeed, as mentioned above, before anything is drawn).
+	if (IN_DemoGetMode() != IN_Demo_Off)
+		RF_Resize(CK_INT(rf_demoScreenWidth, RF_DEFAULT_SCREEN_WIDTH_PIXELS), CK_INT(rf_demoScreenHeight, RF_DEFAULT_SCREEN_HEIGHT_PIXELS));
+	else
+	{
+		const int defaultWidth = CK_INT(rf_demoScreenWidth, RF_DEFAULT_SCREEN_WIDTH_PIXELS);
+		const int defaultHeight = CK_INT(rf_demoScreenHeight, RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+		RF_Resize(CFG_GetConfigInt("screenWidth", defaultWidth), CFG_GetConfigInt("screenHeight", defaultHeight));
+	}
+	CK_ResizeStatusBuffers();
 }
 
 // Cache Box Routines

--- a/src/ck_game.c
+++ b/src/ck_game.c
@@ -657,7 +657,7 @@ void CK_LoadLevel(bool doCache, bool silent)
 	//   before now.
 	// - The fade in is deferred, so we are resizing before anything is seen
 	//   (and indeed, as mentioned above, before anything is drawn).
-	if (IN_DemoGetMode() != IN_Demo_Off)
+	if (CK_VanillaMode())
 		RF_Resize(CK_INT(rf_demoScreenWidth, RF_DEFAULT_SCREEN_WIDTH_PIXELS), CK_INT(rf_demoScreenHeight, RF_DEFAULT_SCREEN_HEIGHT_PIXELS));
 	else
 	{

--- a/src/ck_inter.c
+++ b/src/ck_inter.c
@@ -1010,6 +1010,9 @@ void CK_DrawTerminator(void)
 	VL_DOS_SetPageGap(0, 0, TERMINATORSCREENWIDTH * 8 + 64);
 	#endif
 	VL_ResizeScreen(TERMINATORSCREENWIDTH * 8 + 64, 200);
+#ifndef CK_VANILLA
+	VL_SetScreenSize(RF_DEFAULT_SCREEN_WIDTH_PIXELS, RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+#endif
 	VL_ClearScreen(0);
 
 	// Cache Intro Bitmaps
@@ -1436,6 +1439,9 @@ void CK_ScrollSWText()
 void CK_DrawStarWars()
 {
 	// Keen5 sets the palette to the default one here.
+#ifndef CK_VANILLA
+	VL_SetScreenSize(RF_DEFAULT_SCREEN_WIDTH_PIXELS, RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+#endif
 	VL_ClearScreen(0);
 	VL_SetScrollCoords(0, 0);
 
@@ -1709,7 +1715,12 @@ void CK_SubmitHighScore(int score, uint16_t arg_4)
 	{
 		ck_inHighScores = true;
 		ck_gameState.currentLevel = CK_INT(CK_highScoreLevel, 1);
+
 		CK_LoadLevel(true, false);
+#ifndef CK_VANILLA
+		// We're not technically playing a demo, so the RF size is wrong.
+		VL_SetScreenSize(RF_DEFAULT_SCREEN_WIDTH_PIXELS, RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+#endif
 		CK_OverlayHighScores();
 		US_SetPrintColour(CK_INT(CK_highScoreFontColour, 15));
 

--- a/src/ck_keen.c
+++ b/src/ck_keen.c
@@ -1963,13 +1963,13 @@ void CK_ShotThink(CK_object *shot)
 	// Stun things which are offscreen.
 	if ((shot->clipRects.tileX2 < RF_UnitToTile(rf_scrollXUnit)) ||
 		(shot->clipRects.tileY2 < RF_UnitToTile(rf_scrollYUnit)) ||
-		(shot->clipRects.tileX1 > RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320)) ||
-		(shot->clipRects.tileY1 > RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208)))
+		(shot->clipRects.tileX1 > RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles()) ||
+		(shot->clipRects.tileY1 > RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles()))
 	{
 		if ((shot->clipRects.tileX2 + 10 < RF_UnitToTile(rf_scrollXUnit)) ||
-			(shot->clipRects.tileX1 - 10 > RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320)) ||
+			(shot->clipRects.tileX1 - 10 > RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles()) ||
 			(shot->clipRects.tileY2 + 6 < RF_UnitToTile(rf_scrollYUnit)) ||
-			(shot->clipRects.tileY1 - 6 > RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208)))
+			(shot->clipRects.tileY1 - 6 > RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles()))
 		{
 			CK_RemoveObj(shot);
 			return;

--- a/src/ck_main.c
+++ b/src/ck_main.c
@@ -107,6 +107,18 @@ void CK_ShutdownID(void)
 #endif
 }
 
+// Resize or create the video surfaces for the Status screen
+void CK_ResizeStatusBuffers()
+{
+	if (ck_statusSurface)
+		VL_DestroySurface(ck_statusSurface);
+	if (ck_backupSurface)
+		VL_DestroySurface(ck_backupSurface);
+
+	ck_statusSurface = VL_CreateSurface(RF_BUFFER_WIDTH_PIXELS, STATUS_H + 16 + 16);
+	ck_backupSurface = VL_CreateSurface(RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS);
+}
+
 /*
  * Start the game!
  */
@@ -169,15 +181,20 @@ void CK_InitGame()
 
 	// Wolf loads fonts here, but we do it in CA_Startup()?
 
-	RF_Startup(320, 200);
+#ifdef CK_VANILLA
+	RF_Startup(RF_DEFAULT_SCREEN_WIDTH_PIXELS,RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+#else
+	const int defaultWidth = CK_INT(rf_demoScreenWidth, RF_DEFAULT_SCREEN_WIDTH_PIXELS);
+	const int defaultHeight = CK_INT(rf_demoScreenHeight, RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+	RF_Startup(CFG_GetConfigInt("screenWidth", defaultWidth), CFG_GetConfigInt("screenHeight", defaultHeight));
+#endif
 
 	VL_ColorBorder(3);
 	VL_ClearScreen(0);
 	VL_Present();
 
 	// Create a surface for the dropdown menu
-	ck_statusSurface = VL_CreateSurface(RF_BUFFER_WIDTH_PIXELS, STATUS_H + 16 + 16);
-	ck_backupSurface = VL_CreateSurface(RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS);
+	CK_ResizeStatusBuffers();
 }
 
 /*

--- a/src/ck_main.c
+++ b/src/ck_main.c
@@ -169,7 +169,7 @@ void CK_InitGame()
 
 	// Wolf loads fonts here, but we do it in CA_Startup()?
 
-	RF_Startup();
+	RF_Startup(320, 200);
 
 	VL_ColorBorder(3);
 	VL_ClearScreen(0);

--- a/src/ck_map.c
+++ b/src/ck_map.c
@@ -516,8 +516,8 @@ void CK_AnimateMapTeleporter(int tileX, int tileY)
 	for (CK_object *obj = ck_keenObj->next; obj != NULL; obj = obj->next)
 	{
 
-		if (obj->active || obj->type != 8 ||
-			obj->clipRects.tileX2 < (rf_scrollXUnit >> 8) - 1 || obj->clipRects.tileX1 > (rf_scrollXUnit >> 8) + (320 >> 4) + 1 || obj->clipRects.tileY2 < (rf_scrollYUnit >> 8) - 1 || obj->clipRects.tileY1 > (rf_scrollYUnit >> 8) + (208 >> 4) + 1)
+		if (obj->active || obj->type != CT5_MapFlag ||
+			obj->clipRects.tileX2 < RF_UnitToTile(rf_scrollXUnit) - 1 || obj->clipRects.tileX1 > RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles() + 1 || obj->clipRects.tileY2 < RF_UnitToTile(rf_scrollYUnit) - 1 || obj->clipRects.tileY1 > RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles() + 1)
 			continue;
 
 		obj->visible = 1;

--- a/src/ck_phys.c
+++ b/src/ck_phys.c
@@ -836,7 +836,7 @@ void CK_SetAction2(CK_object *obj, CK_action *act)
 bool CK_ObjectVisible(CK_object *obj)
 {
 	// TODO: Use ScrollX0_T,  ScrollX1_T and co. directly?
-	if (obj->clipRects.tileX2 < RF_UnitToTile(rf_scrollXUnit) || obj->clipRects.tileY2 < RF_UnitToTile(rf_scrollYUnit) || obj->clipRects.tileX1 > (RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320)) || obj->clipRects.tileY1 > (RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208)))
+	if (obj->clipRects.tileX2 < RF_UnitToTile(rf_scrollXUnit) || obj->clipRects.tileY2 < RF_UnitToTile(rf_scrollYUnit) || obj->clipRects.tileX1 > (RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles()) || obj->clipRects.tileY1 > (RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles()))
 	{
 		return false;
 	}

--- a/src/ck_play.c
+++ b/src/ck_play.c
@@ -1508,16 +1508,18 @@ void CK_DrawStatusWindow(void)
 	int si, i, oldcolor;
 
 	// Draw the backdrop
-	int var2 = 64;
+	int statusX = STATUS_X;
 	int di = 16;
 	int statusWidth = STATUS_W - 8;
 	int statusHeight = STATUS_H - 8;
+	int leftColX = STATUS_X + 16;
+	int rightColX = STATUS_X + 112;
 
-	VHB_DrawTile8(var2, di, 54);
-	VHB_DrawTile8(var2, di + statusHeight, 60);
-	si = var2 + 8;
+	VHB_DrawTile8(statusX, di, 54);
+	VHB_DrawTile8(statusX, di + statusHeight, 60);
+	si = statusX + 8;
 
-	while (var2 + statusWidth - 8 >= si)
+	while (statusX + statusWidth - 8 >= si)
 	{
 
 		VHB_DrawTile8(si, di, 55);
@@ -1533,12 +1535,12 @@ void CK_DrawStatusWindow(void)
 	while (di + statusHeight - 8 >= si)
 	{
 
-		VHB_DrawTile8(var2, si, 57);
-		VHB_DrawTile8(var2 + statusWidth, si, 59);
+		VHB_DrawTile8(statusX, si, 57);
+		VHB_DrawTile8(statusX + statusWidth, si, 59);
 		si += 8;
 	}
 
-	VHB_Bar(72, 24, 176, 136, 7);
+	VHB_Bar(STATUS_X + 8, STATUS_Y + 8, 176, 136, 7);
 
 	// Print the stuff
 	oldcolor = US_GetPrintColour();
@@ -1547,11 +1549,11 @@ void CK_DrawStatusWindow(void)
 	uint16_t strW, strH;
 	char str[256];
 	US_SetPrintY(28);
-	US_SetWindowX(80);
+	US_SetWindowX(leftColX);
 	US_SetWindowW(160);
 	US_SetPrintColour(15);
 	US_CPrint(CK_STRING(ck_str_statusLocation));
-	VHB_Bar(79, 38, 162, 20, 15);
+	VHB_Bar(leftColX - 1, 38, 162, 20, 15);
 	strcpy(str, CK_STRINGELEMENT(ck_str_levelNames, ca_mapOn));
 	CK_MeasureMultiline(str, &strW, &strH);
 	US_SetPrintY((20 - strH) / 2 + 40 - 2);
@@ -1559,21 +1561,21 @@ void CK_DrawStatusWindow(void)
 
 	// Score
 	US_SetPrintY(61);
-	US_SetWindowX(80);
+	US_SetWindowX(leftColX);
 	US_SetWindowW(64);
 	US_SetPrintColour(15);
 	US_CPrint(CK_STRING(ck_str_statusScore));
 
-	VHB_Bar(79, 71, 66, 10, 0);
-	CK_DrawLongRight(80, 72, 8, 41, ck_gameState.keenScore);
+	VHB_Bar(STATUS_X + 16, 71, 66, 10, 0);
+	CK_DrawLongRight(leftColX, 72, 8, 41, ck_gameState.keenScore);
 
 	// Extra man
 	US_SetPrintY(61);
-	US_SetWindowX(176);
+	US_SetWindowX(rightColX);
 	US_SetWindowW(64);
 	US_CPrint(CK_STRING(ck_str_statusExtra));
-	VHB_Bar(175, 71, 66, 10, 0);
-	CK_DrawLongRight(176, 72, 8, 41, ck_gameState.nextKeenAt);
+	VHB_Bar(rightColX - 1, 71, 66, 10, 0);
+	CK_DrawLongRight(rightColX, 72, 8, 41, ck_gameState.nextKeenAt);
 
 	// Episode-dependent field
 	switch (ck_currentEpisode->ep)
@@ -1581,49 +1583,49 @@ void CK_DrawStatusWindow(void)
 #ifdef WITH_KEEN4
 	case EP_CK4:
 		US_SetPrintY(85);
-		US_SetWindowX(80);
+		US_SetWindowX(leftColX);
 		US_SetWindowW(64);
 		US_CPrint(CK_STRING(ck4_str_statusRescued));
 
-		VHB_Bar(79, 95, 66, 10, 0);
+		VHB_Bar(leftColX - 1, 95, 66, 10, 0);
 		for (int i = 0; i < ck_gameState.ep.ck4.membersRescued; i++)
 		{
-			VHB_DrawTile8(80 + 8 * i, 96, 40);
+			VHB_DrawTile8(leftColX + 8 * i, 96, 40);
 		}
 		break;
 #endif
 #ifdef WITH_KEEN5
 	case EP_CK5:
 		US_SetPrintY(91);
-		US_SetPrintX(80);
+		US_SetPrintX(leftColX);
 		US_Print(CK_STRING(ck5_str_statusKeycard));
 
-		VHB_Bar(135, 90, 10, 10, 0);
+		VHB_Bar(leftColX + 56 - 1, 90, 10, 10, 0);
 		if (ck_gameState.ep.ck5.securityCard)
-			VHB_DrawTile8(136, 91, 40);
+			VHB_DrawTile8(leftColX + 56, 91, 40);
 		break;
 #endif
 #ifdef WITH_KEEN6
 	case EP_CK6:
-		US_SetPrintX(80);
+		US_SetPrintX(leftColX);
 		US_SetPrintY(96);
 		US_Print(CK_STRING(ck6_str_statusItems));
-		VHB_Bar(127, 95, 26, 10, 0);
+		VHB_Bar(leftColX + 48 - 1, 95, 26, 10, 0);
 
 		if (ck_gameState.ep.ck6.sandwich == 1)
-			VHB_DrawTile8(128, 96, 2);
+			VHB_DrawTile8(leftColX + 48, 96, 2);
 		else
-			VHB_DrawTile8(128, 96, 1);
+			VHB_DrawTile8(leftColX + 48, 96, 1);
 
 		if (ck_gameState.ep.ck6.rope == 1)
-			VHB_DrawTile8(136, 96, 4);
+			VHB_DrawTile8(leftColX + 56, 96, 4);
 		else
-			VHB_DrawTile8(136, 96, 3);
+			VHB_DrawTile8(leftColX + 56, 96, 3);
 
 		if (ck_gameState.ep.ck6.passcard == 1)
-			VHB_DrawTile8(144, 96, 6);
+			VHB_DrawTile8(leftColX + 64, 96, 6);
 		else
-			VHB_DrawTile8(144, 96, 5);
+			VHB_DrawTile8(leftColX + 64, 96, 5);
 		break;
 #endif
 	default:
@@ -1632,14 +1634,14 @@ void CK_DrawStatusWindow(void)
 
 	// Difficulty
 	US_SetPrintY(85);
-	US_SetWindowX(176);
+	US_SetWindowX(rightColX);
 	US_SetWindowW(64);
 	US_SetPrintColour(15);
 	US_CPrint(CK_STRING(ck_str_statusLevel));
-	VHB_Bar(175, 95, 66, 10, 15);
+	VHB_Bar(rightColX - 1, 95, 66, 10, 15);
 
 	US_SetPrintY(96);
-	US_SetWindowX(176);
+	US_SetWindowX(rightColX);
 	US_SetWindowW(64);
 	US_SetPrintColour(15);
 
@@ -1659,39 +1661,43 @@ void CK_DrawStatusWindow(void)
 	}
 
 	// Key gems
-	US_SetPrintX(80);
+	int gemX = leftColX + 40;
+	US_SetPrintX(leftColX);
 	US_SetPrintY(112);
 	US_SetPrintColour(15);
 	US_Print(CK_STRING(ck_str_statusKeys));
 
-	VHB_Bar(119, 111, 34, 10, 0);
+	VHB_Bar(gemX - 1, 111, 34, 10, 0);
 
 	for (i = 0; i < 4; i++)
 	{
 		if (ck_gameState.keyGems[i])
-			VHB_DrawTile8(120 + i * 8, 112, 36 + i);
+			VHB_DrawTile8(gemX + i * 8, 112, 36 + i);
 	}
 
 	// AMMO
-	US_SetPrintX(176);
+	int ammoX = rightColX + 40;
+	US_SetPrintX(rightColX);
 	US_SetPrintY(112);
 	US_Print(CK_STRING(ck_str_statusAmmo));
-	VHB_Bar(215, 111, 26, 10, 0);
-	CK_DrawLongRight(216, 112, 3, 41, ck_gameState.numShots);
+	VHB_Bar(ammoX - 1, 111, 26, 10, 0);
+	CK_DrawLongRight(ammoX, 112, 3, 41, ck_gameState.numShots);
 
 	// Lives
-	US_SetPrintX(80);
+	int livesX = leftColX + 48;
+	US_SetPrintX(leftColX);
 	US_SetPrintY(128);
 	US_Print(CK_STRING(ck_str_statusLives));
-	VHB_Bar(127, 127, 18, 10, 0);
-	CK_DrawLongRight(128, 128, 2, 41, ck_gameState.numLives);
+	VHB_Bar(livesX - 1, 127, 18, 10, 0);
+	CK_DrawLongRight(livesX, 128, 2, 41, ck_gameState.numLives);
 
 	// Lifeups
-	US_SetPrintX(176);
+	int lifeUpX = rightColX + 48;
+	US_SetPrintX(rightColX);
 	US_SetPrintY(128);
 	US_Print(CK_STRING(ck_str_statusCentilives));
-	VHB_Bar(224, 127, 16, 10, 0);
-	CK_DrawLongRight(224, 128, 2, 41, ck_gameState.numCentilife);
+	VHB_Bar(lifeUpX, 127, 16, 10, 0);	// NOTE: Unlike the others, this isn't -1 even in the original.
+	CK_DrawLongRight(lifeUpX, 128, 2, 41, ck_gameState.numCentilife);
 
 	// Episode-dependent field
 	int addX = 0;
@@ -1701,10 +1707,10 @@ void CK_DrawStatusWindow(void)
 	case EP_CK4:
 
 		// Wetsuit
-		VHB_Bar(79, 143, 66, 10, 15);
+		VHB_Bar(leftColX - 1, 143, 66, 10, 15);
 
 		US_SetPrintY(144);
-		US_SetWindowX(80);
+		US_SetWindowX(leftColX);
 		US_SetWindowW(64);
 		US_SetPrintColour(15);
 		US_CPrint(ck_gameState.ep.ck4.wetsuit ? CK_STRING(ck4_str_statusWetsuit) : CK_STRING(ck4_str_statusNoWetsuit));
@@ -1720,7 +1726,7 @@ void CK_DrawStatusWindow(void)
 
 		for (int y = 0; y < 2; y++)
 			for (int x = 0; x < 10; x++)
-				VHB_DrawTile8(120 + 8 * (x + addX), 140 + 8 * y, 72 + y * 10 + x);
+				VHB_DrawTile8(leftColX + 40 + 8 * (x + addX), 140 + 8 * y, 72 + y * 10 + x);
 
 		break;
 	default:
@@ -1738,6 +1744,8 @@ void CK_ScrollStatusWindow(void)
 	int scrX = VL_GetScrollX() & 8;
 	int scrY = VL_GetScrollY() % 16;
 	int statusWindowXPx = STATUS_X + scrX;
+	int sidePicX = STATUS_X - 24;
+	int topPicX = STATUS_X + 72;
 
 	// Check if there's some game visible behind the top of the window.
 	if (ck_statusWindowYPx > STATUS_H)
@@ -1750,7 +1758,7 @@ void CK_ScrollStatusWindow(void)
 					STATUS_W, ck_statusWindowYPx);
 
 		// MPic atop the statusbox
-		VH_DrawMaskedBitmap(136 + scrX, (ck_statusWindowYPx - STATUS_BOTTOM) + scrY,
+		VH_DrawMaskedBitmap(topPicX + scrX, (ck_statusWindowYPx - STATUS_BOTTOM) + scrY,
 				CK_CHUNKNUM(MPIC_STATUSRIGHT));
 		
 		// Set up the position for the status box.
@@ -1797,8 +1805,8 @@ void CK_ScrollStatusWindow(void)
 		if (height > 0)
 		{
 			VL_SurfaceToScreen(ck_statusSurface,
-					40 + scrX, 0,
-					40 + scrX, 0,
+					sidePicX + scrX, 0,
+					sidePicX + scrX, 0,
 					24, height);
 		}
 
@@ -1811,13 +1819,13 @@ void CK_ScrollStatusWindow(void)
 		// Reset the area under the masked pic to the left
 		if (height > 0)
 		{
-			VL_SurfaceToScreen(ck_statusSurface, 40 + scrX % 16, 0, 40 + scrX % 16, 0, 24, height);
+			VL_SurfaceToScreen(ck_statusSurface, sidePicX + scrX % 16, 0, sidePicX + scrX % 16, 0, 24, height);
 		}
 	}
 
 	if (ck_statusWindowYPx >= 72)
 	{
-		VH_DrawMaskedBitmap(40 + scrX, ck_statusWindowYPx - STATUS_BOTTOM + scrY,
+		VH_DrawMaskedBitmap(sidePicX + scrX, ck_statusWindowYPx - STATUS_BOTTOM + scrY,
 				CK_CHUNKNUM(MPIC_STATUSLEFT));
 	}
 }

--- a/src/ck_play.c
+++ b/src/ck_play.c
@@ -1936,29 +1936,34 @@ void CK_CentreCamera(CK_object *obj)
 {
 	uint16_t screenX, screenY;
 
-	screenYpx = 140;
+	// This is always set as though Keen is in-level, as the world map camera doesn't use this variable.
+	screenYpx = CK_VanillaMode() ? 140 : CK_PlayHeightPixels() / 2 + 36;
 
-	if (obj->posX < RF_PixelToUnit(152))
+	int screenCentreX = CK_VanillaMode() ? RF_PixelToUnit(152) : CK_PlayWidthUnits() / 2 - RF_PixelToUnit(8);
+
+	if (obj->posX < screenCentreX)
 		screenX = 0;
 	else
-		screenX = obj->posX - RF_PixelToUnit(152);
+		screenX = obj->posX - screenCentreX;
 
-	if (ca_mapOn == 0)
+	if (ca_mapOn == CK_INT(ck_worldMapNumber, 0))
 	{
 		// World Map
-		if (obj->posY < RF_PixelToUnit(80))
+		int mapCentreY = CK_VanillaMode() ? RF_PixelToUnit(80) : CK_PlayHeightUnits() / 2 - RF_PixelToUnit(24);
+		if (obj->posY < mapCentreY)
 			screenY = 0;
 		else
-			screenY = obj->posY - RF_PixelToUnit(80);
+			screenY = obj->posY - mapCentreY;
 	}
 	else
 	{
 		// In Level
-		if (obj->clipRects.unitY2 < RF_PixelToUnit(140))
+		int screenCentreY = CK_VanillaMode() ? RF_PixelToUnit(140) : CK_PlayHeightUnits() / 2 + RF_PixelToUnit(36);
+		if (obj->clipRects.unitY2 < screenCentreY)
 			screenY = 0;
 
 		else
-			screenY = obj->clipRects.unitY2 - RF_PixelToUnit(140);
+			screenY = obj->clipRects.unitY2 - screenCentreY;
 	}
 
 	// TODO: Find out why this is locking the game up
@@ -1967,9 +1972,9 @@ void CK_CentreCamera(CK_object *obj)
 
 	//TODO: This is 4 in Andy's disasm.
 	ck_activeX0Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) - CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
-	ck_activeX1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320) + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
+	ck_activeX1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles() + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
 	ck_activeY0Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) - CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
-	ck_activeY1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208) + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
+	ck_activeY1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles() + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
 }
 
 /*
@@ -1983,19 +1988,24 @@ void CK_MapCamera(CK_object *keen)
 	if (ck_scrollDisabled)
 		return;
 
+	int minScrollX = CK_VanillaMode() ? RF_PixelToUnit(144) : CK_PlayWidthUnits() / 2 - RF_PixelToUnit(16);
+	int maxScrollX = CK_VanillaMode() ? RF_PixelToUnit(192) : CK_PlayWidthUnits() / 2 + RF_PixelToUnit(32);
+	int minScrollY = CK_VanillaMode() ? RF_PixelToUnit(80) : CK_PlayHeightUnits() / 2 - RF_PixelToUnit(24);
+	int maxScrollY = CK_VanillaMode() ? RF_PixelToUnit(112) : CK_PlayHeightUnits() / 2 + RF_PixelToUnit(8);
+
 	// Scroll Left, Right, or nowhere
-	if (keen->clipRects.unitX1 < rf_scrollXUnit + RF_PixelToUnit(144))
-		scr_x = keen->clipRects.unitX1 - (rf_scrollXUnit + RF_PixelToUnit(144));
-	else if (keen->clipRects.unitX2 > rf_scrollXUnit + RF_PixelToUnit(192))
-		scr_x = keen->clipRects.unitX2 + 16 - (rf_scrollXUnit + RF_PixelToUnit(192));
+	if (keen->clipRects.unitX1 < rf_scrollXUnit + minScrollX)
+		scr_x = keen->clipRects.unitX1 - (rf_scrollXUnit + minScrollX);
+	else if (keen->clipRects.unitX2 > rf_scrollXUnit + maxScrollX)
+		scr_x = keen->clipRects.unitX2 + 16 - (rf_scrollXUnit + maxScrollX);
 	else
 		scr_x = 0;
 
 	// Scroll Up, Down, or nowhere
-	if (keen->clipRects.unitY1 < rf_scrollYUnit + RF_PixelToUnit(80))
-		scr_y = keen->clipRects.unitY1 - (rf_scrollYUnit + RF_PixelToUnit(80));
-	else if (keen->clipRects.unitY2 > rf_scrollYUnit + RF_PixelToUnit(112))
-		scr_y = keen->clipRects.unitY2 - (rf_scrollYUnit + RF_PixelToUnit(112));
+	if (keen->clipRects.unitY1 < rf_scrollYUnit + minScrollY)
+		scr_y = keen->clipRects.unitY1 - (rf_scrollYUnit + minScrollY);
+	else if (keen->clipRects.unitY2 > rf_scrollYUnit + maxScrollY)
+		scr_y = keen->clipRects.unitY2 - (rf_scrollYUnit + maxScrollY);
 	else
 		scr_y = 0;
 
@@ -2023,9 +2033,9 @@ void CK_MapCamera(CK_object *keen)
 
 		//TODO: This is 4 in Andy's disasm.
 		ck_activeX0Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) - CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
-		ck_activeX1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320) + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
+		ck_activeX1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles() + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
 		ck_activeY0Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) - CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
-		ck_activeY1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208) + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
+		ck_activeY1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles() + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
 	}
 }
 
@@ -2036,9 +2046,6 @@ void CK_NormalCamera(CK_object *obj)
 
 	int16_t deltaX = 0, deltaY = 0; // in Units
 
-	//TODO: some unknown var must be 0
-	//This var is a "ScrollDisabled flag." If keen dies, it's set so he
-	// can fall out the bottom
 	if (ck_scrollDisabled)
 		return;
 
@@ -2060,21 +2067,25 @@ void CK_NormalCamera(CK_object *obj)
 	}
 
 	// Keep keen's x-coord between 144-192 pixels
-	if (obj->posX < (rf_scrollXUnit + RF_PixelToUnit(144)))
-		deltaX = obj->posX - (rf_scrollXUnit + RF_PixelToUnit(144));
+	int screenCentreX = CK_PlayWidthUnits() / 2;
+	int minScrollX = CK_VanillaMode() ? RF_PixelToUnit(144) : screenCentreX - RF_PixelToUnit(16);
+	int maxScrollX = CK_VanillaMode() ? RF_PixelToUnit(192) : screenCentreX + RF_PixelToUnit(32);
+	if (obj->posX < (rf_scrollXUnit + minScrollX))
+		deltaX = obj->posX - (rf_scrollXUnit + minScrollX);
 
-	if (obj->posX > (rf_scrollXUnit + RF_PixelToUnit(192)))
-		deltaX = obj->posX - (rf_scrollXUnit + RF_PixelToUnit(192));
+	if (obj->posX > (rf_scrollXUnit + maxScrollX))
+		deltaX = obj->posX - (rf_scrollXUnit + maxScrollX);
 
 	// Keen should be able to look up and down.
 	if (obj->currentAction == CK_ACTION(CK_ACT_keenLookUp2))
 	{
 		int16_t pxToMove;
-		if (screenYpx + SD_GetSpriteSync() > 167)
+		int maxLookPx = CK_VanillaMode() ? 167 : CK_PlayHeightPixels() - 33;
+		if (screenYpx + SD_GetSpriteSync() > maxLookPx)
 		{
 			// Keen should never be so low on the screen that his
 			// feet are more than 167 px from the top.
-			pxToMove = 167 - screenYpx;
+			pxToMove = maxLookPx - screenYpx;
 		}
 		else
 		{
@@ -2169,15 +2180,15 @@ void CK_NormalCamera(CK_object *obj)
 	else
 	{
 		// Reset to 140px.
-		screenYpx = 140;
+		screenYpx = CK_VanillaMode() ? 140 : CK_PlayHeightPixels() / 2 + 36;
 	}
 
 	// Scroll the screen to keep keen between 33 and 167 px.
 	if (obj->clipRects.unitY2 < (rf_scrollYUnit + deltaY + RF_PixelToUnit(32)))
 		deltaY += obj->clipRects.unitY2 - (rf_scrollYUnit + deltaY + RF_PixelToUnit(32));
 
-	if (obj->clipRects.unitY2 > (rf_scrollYUnit + deltaY + RF_PixelToUnit(168)))
-		deltaY += obj->clipRects.unitY2 - (rf_scrollYUnit + deltaY + RF_PixelToUnit(168));
+	if (obj->clipRects.unitY2 > (rf_scrollYUnit + deltaY + CK_PlayHeightUnits() - RF_PixelToUnit(40)))
+		deltaY += obj->clipRects.unitY2 - (rf_scrollYUnit + deltaY + CK_PlayHeightUnits() - RF_PixelToUnit(40));
 
 	//Don't scroll more than one tile's worth per frame.
 	if (deltaX || deltaY)
@@ -2199,9 +2210,9 @@ void CK_NormalCamera(CK_object *obj)
 
 		// Update the rectangle of active objects
 		ck_activeX0Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) - CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
-		ck_activeX1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320) + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
+		ck_activeX1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles() + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
 		ck_activeY0Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) - CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
-		ck_activeY1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208) + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
+		ck_activeY1Tile = CK_Cross_max(RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles() + CK_INT(CK_activeLimit, DEFAULT_ACTIVE_LIMIT), 0);
 	}
 }
 
@@ -2245,8 +2256,8 @@ void CK_PlayLoop()
 
 			if (!currentObj->active &&
 				(currentObj->clipRects.tileX2 >= RF_UnitToTile(rf_scrollXUnit) - 1) &&
-				(currentObj->clipRects.tileX1 <= RF_UnitToTile(rf_scrollXUnit) + RF_PixelToTile(320) + 1) &&
-				(currentObj->clipRects.tileY1 <= RF_UnitToTile(rf_scrollYUnit) + RF_PixelToTile(208) + 1) &&
+				(currentObj->clipRects.tileX1 <= RF_UnitToTile(rf_scrollXUnit) + CK_PlayWidthTiles() + 1) &&
+				(currentObj->clipRects.tileY1 <= RF_UnitToTile(rf_scrollYUnit) + CK_PlayHeightTiles() + 1) &&
 				(currentObj->clipRects.tileY2 >= RF_UnitToTile(rf_scrollYUnit) - 1))
 			{
 				currentObj->active = OBJ_ACTIVE;

--- a/src/ck_play.h
+++ b/src/ck_play.h
@@ -44,7 +44,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // Status window constants
 #define STATUS_W 192	// Width in pixels
 #define STATUS_H 152	// Height in pixels
-#define STATUS_X 64	// X-coord in pixels (without scroll adjustment)
+#define STATUS_X ((VL_ScreenWidth() - STATUS_W) / 2)	// X-coord in pixels (without scroll adjustment)
 #define STATUS_Y 16	// Y-coord in pixels when fully down
 #define STATUS_BOTTOM (STATUS_H + STATUS_Y)	// Bottom of status window
 

--- a/src/ck_play.h
+++ b/src/ck_play.h
@@ -23,6 +23,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef CK_VANILLA
+#define CK_VanillaMode() (true)
+#define CK_PlayWidthPixels() (320)
+#define CK_PlayHeightPixels() (208)
+#define CK_PlayWidthTiles() (RF_PixelToTile(CK_PlayWidthPixels()))
+#define CK_PlayHeightTiles() (RF_PixelToTile(CK_PlayHeightPixels()))
+#else
+#include "id_rf.h"
+#include "id_in.h"
+#define CK_VanillaMode() (IN_DemoGetMode() != IN_Demo_Off)
+#define CK_PlayWidthTiles() (RF_SCREEN_WIDTH_TILES)
+#define CK_PlayHeightTiles() (RF_SCREEN_HEIGHT_TILES)
+#define CK_PlayWidthPixels() (RF_TileToPixel(RF_SCREEN_WIDTH_TILES))
+#define CK_PlayHeightPixels() (RF_TileToPixel(RF_SCREEN_HEIGHT_TILES))
+#endif
+#define CK_PlayWidthUnits() (RF_PixelToUnit(CK_PlayWidthPixels()))
+#define CK_PlayHeightUnits() (RF_PixelToUnit(CK_PlayHeightPixels()))
+
 // Status window constants
 #define STATUS_W 192	// Width in pixels
 #define STATUS_H 152	// Height in pixels

--- a/src/ck_text.c
+++ b/src/ck_text.c
@@ -469,6 +469,9 @@ int ShowHelp(void)
 	//CONTROLLER_STATUS cstatus;
 
 	/* Erase the screen */
+#ifndef CK_VANILLA
+	VL_SetScreenSize(320, 200);
+#endif
 	VHB_Bar(0, 0, 320, 200, 4);
 
 	/* Cache graphics */

--- a/src/id_ca.c
+++ b/src/id_ca.c
@@ -1531,6 +1531,7 @@ uint16_t *CA_TilePtrAtPos(int16_t x, int16_t y, int16_t plane)
 	return &CA_mapPlanes[plane][y * CA_MapHeaders[ca_mapOn]->width + x];
 }
 
+bool ca_emulateMapGarbage;
 uint16_t CA_TileAtPos(int16_t x, int16_t y, int16_t plane)
 {
 	// HACK - Somewhat reproducing a glitch occuring in Keen 4: Level 10,
@@ -1539,7 +1540,10 @@ uint16_t CA_TileAtPos(int16_t x, int16_t y, int16_t plane)
 	CA_MapHeader *mapheader = CA_MapHeaders[ca_mapOn];
 	if ((x >= 0) && (x < mapheader->width) && (y >= 0) && (y < mapheader->height))
 		return CA_mapPlanes[plane][y * mapheader->width + x];
-	return (y * x * y * x) % (ca_gfxInfoE.numTiles16 * 2 + ca_gfxInfoE.numTiles16m * 6);
+	if (ca_emulateMapGarbage)
+		return (y * x * y * x) % (ca_gfxInfoE.numTiles16 * 2 + ca_gfxInfoE.numTiles16m * 6);
+	else
+		return 0;
 }
 
 void CA_SetTileAtPos(int16_t x, int16_t y, int16_t plane, uint16_t value)

--- a/src/id_ca.h
+++ b/src/id_ca.h
@@ -109,6 +109,8 @@ extern CA_MapHeader *CA_MapHeaders[CA_NUMMAPS];
 
 extern uint16_t *CA_mapPlanes[CA_NUMMAPPLANES];
 
+extern bool ca_emulateMapGarbage;
+
 extern uint8_t *CA_audio[CA_MAX_AUDIO_CHUNKS];
 
 // Keen: custom cachebox hooks

--- a/src/id_rf.c
+++ b/src/id_rf.c
@@ -46,6 +46,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // tile-by-tile, not pixel by pixel. The smooth-scrolling effect
 // is implemented by changing which part of the buffer is displayed.
 
+#ifdef RF_DYNAMIC_LIMITS
+// We set these to the defaults statically, as ID_VL uses them, and is initialised
+// before ID_RF. We don't support a 0×0 pixel screen buffer, so we have to have
+// _something_.s
+int rf_bufferWidthTiles = RF_TileToPixel(21);
+int rf_bufferHeightTiles = RF_TileToPixel(14);
+int rf_screenWidthPixels = RF_DEFAULT_SCREEN_WIDTH_PIXELS;
+int rf_screenHeightPixels = RF_DEFAULT_SCREEN_HEIGHT_PIXELS;
+#endif
+
 // Scroll blocks prevent the camera from moving beyond a certain row/column
 #define RF_MAX_SCROLLBLOCKS 6
 static int rf_horzScrollBlocks[RF_MAX_SCROLLBLOCKS];
@@ -149,7 +159,11 @@ int rf_demoTics = 3;
 
 // Block dirty state
 #define RF_BUFFER_SIZE (RF_BUFFER_WIDTH_TILES * RF_BUFFER_HEIGHT_TILES)
+#ifdef RF_DYNAMIC_LIMITS
+uint8_t *rf_dirtyBlocks[RF_MAX_BUFFERS];
+#else
 uint8_t rf_dirtyBlocks[RF_MAX_BUFFERS][RF_BUFFER_SIZE];
+#endif
 
 // An offset added to the dirty block buffer to account for scrolling.
 int rf_dirtyBufferOffset = 0;
@@ -607,8 +621,20 @@ void RF_SetDrawFunc(void (*func)(void))
 	rf_drawFunc = func;
 }
 
-void RF_Startup()
+void RF_Startup(int screenWidth, int screenHeight)
 {
+	rf_screenWidthPixels = screenWidth;
+	rf_screenHeightPixels = screenHeight;
+	rf_bufferWidthTiles = RF_PixelToTile_RoundUp(rf_screenWidthPixels) + 1;
+	rf_bufferHeightTiles = RF_PixelToTile_RoundUp(rf_screenHeightPixels) + 1;
+
+	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "RF_Startup(%d, %d): screen in tiles (%d, %d), buffer in tiles (%d, %d)\n",
+		screenWidth, screenHeight, RF_SCREEN_WIDTH_TILES, RF_SCREEN_HEIGHT_TILES, RF_BUFFER_WIDTH_TILES, RF_BUFFER_HEIGHT_TILES);
+
+#ifdef RF_DYNAMIC_LIMITS
+	MM_GetPtr((mm_ptr_t *)&rf_dirtyBlocks[0], RF_BUFFER_SIZE);
+	MM_GetPtr((mm_ptr_t *)&rf_dirtyBlocks[1], RF_BUFFER_SIZE);
+#endif
 	// Create the tile backing buffer
 	rf_tileBuffer = VL_CreateSurface(RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS);
 	rf_minTics = CFG_GetConfigInt("rf_minTics", 2);
@@ -616,10 +642,54 @@ void RF_Startup()
 	rf_demoTics = CFG_GetConfigInt("rf_demoTics", 3);
 
 	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "RF_Startup: tileBuffer = (%d×%d), minTics = %d, maxTics = %d, demoTics = %d\n", RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS, rf_minTics, rf_maxTics, rf_demoTics);
+
+	VL_ResizeScreen(RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS);
+}
+
+void RF_Resize(int screenWidth, int screenHeight)
+{
+	// If we're the same size, don't resize.
+	if (rf_screenWidthPixels == screenWidth && rf_screenHeightPixels == screenHeight)
+		return;
+
+#ifndef RF_DYNAMIC_LIMITS
+	CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "RF_Resize() called, but dynamic limits not supported!\n");
+#else
+	rf_screenWidthPixels = screenWidth;
+	rf_screenHeightPixels = screenHeight;
+	rf_bufferWidthTiles = RF_PixelToTile_RoundUp(rf_screenWidthPixels) + 1;
+	rf_bufferHeightTiles = RF_PixelToTile_RoundUp(rf_screenHeightPixels) + 1;
+
+	// Reset the edge-of-screen scroll blocks.
+	rf_scrollXMaxUnit = RF_TileToUnit(CA_GetMapWidth() - RF_SCREEN_WIDTH_TILES - 2);
+	rf_scrollYMaxUnit = RF_TileToUnit(CA_GetMapHeight() - RF_SCREEN_HEIGHT_TILES - 2);
+
+	CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "RF_Resize(%d, %d): screen in tiles (%d, %d), buffer in tiles (%d, %d)\n",
+			    screenWidth, screenHeight, RF_SCREEN_WIDTH_TILES, RF_SCREEN_HEIGHT_TILES, RF_BUFFER_WIDTH_TILES, RF_BUFFER_HEIGHT_TILES);
+
+	if (rf_dirtyBlocks[0])
+		MM_FreePtr((mm_ptr_t *)&rf_dirtyBlocks[0]);
+	MM_GetPtr((mm_ptr_t *)&rf_dirtyBlocks[0], RF_BUFFER_SIZE);
+	if (rf_dirtyBlocks[1])
+		MM_FreePtr((mm_ptr_t *)&rf_dirtyBlocks[1]);
+	MM_GetPtr((mm_ptr_t *)&rf_dirtyBlocks[1], RF_BUFFER_SIZE);
+
+	// Create the tile backing buffer
+	VL_DestroySurface(rf_tileBuffer);
+	rf_tileBuffer = VL_CreateSurface(RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS);
+
+	VL_ResizeScreen(RF_BUFFER_WIDTH_PIXELS, RF_BUFFER_HEIGHT_PIXELS);
+#endif
 }
 
 void RF_Shutdown()
 {
+#ifdef RF_DYNAMIC_LIMITS
+	if (rf_dirtyBlocks[0])
+		MM_FreePtr((mm_ptr_t *)&rf_dirtyBlocks[0]);
+	if (rf_dirtyBlocks[1])
+		MM_FreePtr((mm_ptr_t *)&rf_dirtyBlocks[1]);
+#endif
 	VL_DestroySurface(rf_tileBuffer);
 }
 
@@ -1448,6 +1518,9 @@ void RF_Refresh()
 
 	// 0xef for the X-direction to match EGA keen's 2px horz scrolling.
 	VL_SetScrollCoords(RF_UnitToPixel(rf_scrollXUnit & 0xef), RF_UnitToPixel(rf_scrollYUnit & 0xff));
+#ifndef CK_VANILLA
+	VL_SetScreenSize(rf_screenWidthPixels, rf_screenHeightPixels);
+#endif
 	VL_SwapOnNextPresent();
 	VL_Present();
 

--- a/src/id_rf.h
+++ b/src/id_rf.h
@@ -38,24 +38,9 @@ typedef struct RF_SpriteDrawEntry
 	struct RF_SpriteDrawEntry *next;
 } RF_SpriteDrawEntry;
 
-// Width/Height of the screen buffers in-game.
-#define RF_BUFFER_WIDTH_TILES 21
-#define RF_BUFFER_HEIGHT_TILES 14
-
-#define RF_BUFFER_WIDTH_PIXELS (RF_BUFFER_WIDTH_TILES << 4)
-#define RF_BUFFER_HEIGHT_PIXELS (RF_BUFFER_HEIGHT_TILES << 4)
-
-#define RF_BUFFER_WIDTH_UNITS (RF_BUFFER_WIDTH_TILES << 8)
-#define RF_BUFFER_HEIGHT_UNITS (RF_BUFFER_HEIGHT_TILES << 8)
-
-// Width/Height of the visible screen in tiles.
-#define RF_SCREEN_WIDTH_TILES 20
-#define RF_SCREEN_HEIGHT_TILES 13
-
-#define PRIORITIES 4
-#define MASKEDTILEPRIORITY 3 // planes go: 0, 1, 2, MTILES, 3
-#define TILEGLOBAL 256
-#define PIXGLOBAL 16
+#ifndef CK_VANILLA
+#define RF_DYNAMIC_LIMITS
+#endif
 
 #define G_T_SHIFT 8 // global >> ?? = tile
 #define G_P_SHIFT 4 // global >> ?? = pixels
@@ -67,6 +52,42 @@ typedef struct RF_SpriteDrawEntry
 #define RF_PixelToUnit(p) ((p) << G_P_SHIFT)
 #define RF_PixelToTile(p) ((p) >> P_T_SHIFT)
 #define RF_TileToPixel(t) ((t) << P_T_SHIFT)
+
+#define RF_PixelToTile_RoundUp(p) ((p + (1 << P_T_SHIFT) - 1) >> P_T_SHIFT)
+
+#define RF_DEFAULT_SCREEN_WIDTH_PIXELS 320
+#define RF_DEFAULT_SCREEN_HEIGHT_PIXELS 200
+
+#ifdef RF_DYNAMIC_LIMITS
+// Width/Height of the visible screen in tiles.
+extern int rf_screenWidthPixels, rf_screenHeightPixels;
+#define RF_SCREEN_WIDTH_TILES RF_PixelToTile_RoundUp(rf_screenWidthPixels)
+#define RF_SCREEN_HEIGHT_TILES RF_PixelToTile_RoundUp(rf_screenHeightPixels)
+
+extern int rf_bufferWidthTiles, rf_bufferHeightTiles;
+#define RF_BUFFER_WIDTH_TILES rf_bufferWidthTiles
+#define RF_BUFFER_HEIGHT_TILES rf_bufferHeightTiles
+
+#else
+// Width/Height of the visible screen in tiles.
+#define RF_SCREEN_WIDTH_TILES RF_PixelToTile_RoundUp(RF_DEFAULT_SCREEN_WIDTH_PIXELS) //20
+#define RF_SCREEN_HEIGHT_TILES RF_PixelToTile_RoundUp(RF_DEFAULT_SCREEN_HEIGHT_PIXELS) //13
+
+// Width/Height of the screen buffers in-game.
+#define RF_BUFFER_WIDTH_TILES RF_DEFAULT_SCREEN_WIDTH_TILES + 1 //21
+#define RF_BUFFER_HEIGHT_TILES RF_DEFAULT_SCREEN_HEIGHT_TILES + 1 //14
+#endif
+
+#define RF_BUFFER_WIDTH_PIXELS (RF_BUFFER_WIDTH_TILES << 4)
+#define RF_BUFFER_HEIGHT_PIXELS (RF_BUFFER_HEIGHT_TILES << 4)
+
+#define RF_BUFFER_WIDTH_UNITS (RF_BUFFER_WIDTH_TILES << 8)
+#define RF_BUFFER_HEIGHT_UNITS (RF_BUFFER_HEIGHT_TILES << 8)
+
+#define PRIORITIES 4
+#define MASKEDTILEPRIORITY 3 // planes go: 0, 1, 2, MTILES, 3
+#define TILEGLOBAL 256
+#define PIXGLOBAL 16
 
 extern int rf_scrollXUnit, rf_scrollYUnit;
 extern int rf_scrollXMinUnit;
@@ -82,7 +103,8 @@ uint8_t RFL_IsBlockDirty(int x, int y, int page);
 void RF_SetScrollBlock(int tileX, int tileY, bool vertical);
 void RF_MarkTileGraphics();
 void RF_SetDrawFunc(void (*func)(void));
-void RF_Startup();
+void RF_Startup(int screenPixelsX, int screenPixelsY);
+void RF_Resize(int screenWidth, int screenHeight);
 void RF_Shutdown();
 void RF_NewMap(void);
 void RF_RenderTile16(int x, int y, int tile);

--- a/src/id_us_1.c
+++ b/src/id_us_1.c
@@ -87,8 +87,8 @@ static int16_t us_printY;
 static int16_t us_printFont = 0;
 static int8_t us_printColour = 15;
 
-#define US_WINDOW_MAX_X 320
-#define US_WINDOW_MAX_Y 200
+#define US_WINDOW_MAX_X VL_ScreenWidth()
+#define US_WINDOW_MAX_Y VL_ScreenHeight()
 
 bool (*p_save_game)(FS_File handle);
 bool (*p_load_game)(FS_File handle, bool fromMenu);

--- a/src/id_us_2.c
+++ b/src/id_us_2.c
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <string.h>
 
 #include "id_heads.h"
+#include "id_rf.h"
 #include "id_in.h"
 #include "id_sd.h"
 #include "id_us.h"
@@ -1073,6 +1074,9 @@ void US_RunCards()
 	// load all menu stuff and draw main menu
 	USL_BeginCards();
 	US_DrawCards();
+#ifndef CK_VANILLA
+	VL_SetScreenSize(RF_DEFAULT_SCREEN_WIDTH_PIXELS, RF_DEFAULT_SCREEN_HEIGHT_PIXELS);
+#endif
 
 	controller_dy = 0;
 	prev_controller_motion = 0;

--- a/src/id_vl.c
+++ b/src/id_vl.c
@@ -987,6 +987,15 @@ int VL_GetScrollY(void)
 	return vl_scrollYpixels;
 }
 
+static int vl_screenWidth = RF_DEFAULT_SCREEN_WIDTH_PIXELS;
+static int vl_screenHeight = RF_DEFAULT_SCREEN_HEIGHT_PIXELS;
+
+void VL_SetScreenSize(int width, int height)
+{
+	vl_screenWidth = width;
+	vl_screenHeight = height;
+}
+
 // The full on-screen region, including overscan border.
 int vl_fullRgn_x;
 int vl_fullRgn_y;
@@ -1003,17 +1012,31 @@ int vl_renderRgn_h;
 int vl_integerWidth;
 int vl_integerHeight;
 
-void VL_CalculateRenderRegions(int realW, int realH)
+
+void VL_CalculateRenderRegions(int vgaW, int vgaH, int realW, int realH)
 {
+	int scaledBorderW = VL_VGA_GFX_SCALED_LEFTBORDER_WIDTH + VL_VGA_GFX_SCALED_RIGHTBORDER_WIDTH;
+	int scaledBorderH = VL_VGA_GFX_SCALED_TOPBORDER_HEIGHT + VL_VGA_GFX_SCALED_BOTTOMBORDER_HEIGHT;
+
+	// Width/Height in CRT pixels (i.e., non-square pixels, but with line doubling applied).
+	int scaledWidthWithBorder = vgaW * VL_VGA_GFX_WIDTH_SCALEFACTOR + (vl_hasOverscanBorder ? scaledBorderW : 0);
+	int scaledHeightWithBorder = vgaH *VL_VGA_GFX_HEIGHT_SCALEFACTOR + (vl_hasOverscanBorder ? scaledBorderH : 0);
+	int shrunkHeightWithBorder = scaledHeightWithBorder / VL_VGA_GFX_HEIGHT_SCALEFACTOR;
+
+	int pixelAspectNumerator = 6;
+	int pixelAspectDenominator = vl_isAspectCorrected ? 5 : 6;
 	if (vl_isAspectCorrected)
 	{
+		int unscaledAspectW = scaledWidthWithBorder * VL_VGA_GFX_HEIGHT_SCALEFACTOR;
+		int unscaledAspectH = pixelAspectNumerator * VL_VGA_GFX_WIDTH_SCALEFACTOR * scaledHeightWithBorder / pixelAspectDenominator;
 		/* HACK: Naturally, the ratio to compare to may be 4:3,
 		 * but we use the default window dimensions instead
 		 * (so 4:3 covers the contents without the overscan border).
 		 */
-		if (realW * VL_DEFAULT_WINDOW_HEIGHT(2) > realH * VL_DEFAULT_WINDOW_WIDTH(2)) // Wider than default ratio
+		//printf("aspectW = %d, aspechH = %d, 4:%d\n", unscaledAspectW, unscaledAspectH, unscaledAspectW * 4 /unscaledAspectH);
+		if (realW * unscaledAspectH > realH * unscaledAspectW) // Wider than default ratio
 		{
-			vl_fullRgn_w = realH * VL_DEFAULT_WINDOW_WIDTH(2) / VL_DEFAULT_WINDOW_HEIGHT(2);
+			vl_fullRgn_w = realH * unscaledAspectW / unscaledAspectH;
 			vl_fullRgn_h = realH;
 			vl_fullRgn_x = (realW - vl_fullRgn_w) / 2;
 			vl_fullRgn_y = 0;
@@ -1021,7 +1044,7 @@ void VL_CalculateRenderRegions(int realW, int realH)
 		else // Thinner or equal to default ratio
 		{
 			vl_fullRgn_w = realW;
-			vl_fullRgn_h = realW * VL_DEFAULT_WINDOW_HEIGHT(2) / VL_DEFAULT_WINDOW_WIDTH(2);
+			vl_fullRgn_h = realW * unscaledAspectH / unscaledAspectW;
 			vl_fullRgn_x = 0;
 			vl_fullRgn_y = (realH - vl_fullRgn_h) / 2;
 		}
@@ -1037,8 +1060,8 @@ void VL_CalculateRenderRegions(int realW, int realH)
 
 	if (vl_isIntegerScaled)
 	{
-		vl_fullRgn_w = CK_Cross_max((vl_fullRgn_w / VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER) * VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER);
-		vl_fullRgn_h = CK_Cross_max((vl_fullRgn_h / VL_VGA_GFX_SHRUNK_HEIGHT_PLUS_BORDER) * VL_VGA_GFX_SHRUNK_HEIGHT_PLUS_BORDER, VL_VGA_GFX_SHRUNK_HEIGHT_PLUS_BORDER);
+		vl_fullRgn_w = CK_Cross_max((vl_fullRgn_w / scaledWidthWithBorder) * scaledWidthWithBorder, scaledWidthWithBorder);
+		vl_fullRgn_h = CK_Cross_max((vl_fullRgn_h / shrunkHeightWithBorder) * shrunkHeightWithBorder, shrunkHeightWithBorder);
 		vl_fullRgn_x = (realW - vl_fullRgn_w)/2;
 		vl_fullRgn_y = (realH - vl_fullRgn_h)/2;
 		vl_integerWidth = vl_fullRgn_w; 
@@ -1046,26 +1069,26 @@ void VL_CalculateRenderRegions(int realW, int realH)
 	}
 	else
 	{
-		vl_integerWidth = CK_Cross_max((vl_fullRgn_w / VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER) * VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER);
-		vl_integerHeight = CK_Cross_max((vl_fullRgn_h / VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER) * VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER, VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER);
+		vl_integerWidth = CK_Cross_max((vl_fullRgn_w / scaledWidthWithBorder) * scaledWidthWithBorder, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER);
+		vl_integerHeight = CK_Cross_max((vl_fullRgn_h / scaledHeightWithBorder) * scaledHeightWithBorder, scaledHeightWithBorder);
 	}
 
 	vl_renderRgn_x =
 		vl_integerWidth * VL_VGA_GFX_SCALED_LEFTBORDER_WIDTH /
-		(VL_VGA_GFX_WIDTH_SCALEFACTOR * VL_EGAVGA_GFX_WIDTH +
+		(VL_VGA_GFX_WIDTH_SCALEFACTOR * vgaW +
 			VL_VGA_GFX_SCALED_LEFTBORDER_WIDTH + VL_VGA_GFX_SCALED_RIGHTBORDER_WIDTH);
 	vl_renderRgn_y =
 		vl_integerHeight * VL_VGA_GFX_SCALED_TOPBORDER_HEIGHT /
-		(VL_VGA_GFX_HEIGHT_SCALEFACTOR * VL_EGAVGA_GFX_HEIGHT +
+		(VL_VGA_GFX_HEIGHT_SCALEFACTOR * vgaH +
 			VL_VGA_GFX_SCALED_TOPBORDER_HEIGHT + VL_VGA_GFX_SCALED_BOTTOMBORDER_HEIGHT);
 	// Tricky calculations that preserve symmetry for the VGA
 	vl_renderRgn_w = vl_integerWidth -
 		vl_integerWidth * (VL_VGA_GFX_SCALED_LEFTBORDER_WIDTH + VL_VGA_GFX_SCALED_RIGHTBORDER_WIDTH) /
-			(VL_VGA_GFX_WIDTH_SCALEFACTOR * VL_EGAVGA_GFX_WIDTH +
+			(VL_VGA_GFX_WIDTH_SCALEFACTOR * vgaW +
 				VL_VGA_GFX_SCALED_LEFTBORDER_WIDTH + VL_VGA_GFX_SCALED_RIGHTBORDER_WIDTH);
 	vl_renderRgn_h = vl_integerHeight -
 		vl_integerHeight * (VL_VGA_GFX_SCALED_TOPBORDER_HEIGHT + VL_VGA_GFX_SCALED_BOTTOMBORDER_HEIGHT) /
-			(VL_VGA_GFX_HEIGHT_SCALEFACTOR * VL_EGAVGA_GFX_HEIGHT +
+			(VL_VGA_GFX_HEIGHT_SCALEFACTOR * vgaH +
 				VL_VGA_GFX_SCALED_TOPBORDER_HEIGHT + VL_VGA_GFX_SCALED_BOTTOMBORDER_HEIGHT);
 }
 
@@ -1092,6 +1115,16 @@ void VL_ClearScreen(int colour)
 	vl_currentBackend->getSurfaceDimensions(vl_emuegavgaadapter.screen,
 		&screenWidth, &screenHeight);
 	VL_ScreenRect(0, 0, screenWidth, screenHeight, colour);
+}
+
+int VL_ScreenWidth()
+{
+	return vl_screenWidth;
+}
+
+int VL_ScreenHeight()
+{
+	return vl_screenHeight;
 }
 
 void VL_SetMapMask(int mapmask)
@@ -1129,6 +1162,6 @@ void VL_SwapOnNextPresent()
 void VL_Present()
 {
 	vl_lastFrameTime = SD_GetTimeCount();
-	vl_currentBackend->present(vl_emuegavgaadapter.screen, vl_scrollXpixels, vl_scrollYpixels, !vl_swapOnNextPresent);
+	vl_currentBackend->present(vl_emuegavgaadapter.screen, vl_scrollXpixels, vl_scrollYpixels, vl_screenWidth, vl_screenHeight, !vl_swapOnNextPresent);
 	vl_swapOnNextPresent = false;
 }

--- a/src/id_vl.h
+++ b/src/id_vl.h
@@ -111,7 +111,7 @@ typedef struct VL_Backend
 	void (*bitBlitToSurface)(void *src, void *dst_surface, int x, int y, int w, int h, int colour);
 	void (*bitInvBlitToSurface)(void *src, void *dst_surface, int x, int y, int w, int h, int colour);
 	void (*scrollSurface)(void *surface, int x, int y);
-	void (*present)(void *surface, int scrollXpx, int scrollYpx, bool singleBuffered);
+	void (*present)(void *surface, int scrollXpx, int scrollYpx, int width, int height, bool singleBuffered);
 	int (*getActiveBufferId)(void *surface);
 	int (*getNumBuffers)(void *surface);
 	void (*syncBuffers)(void *surface);
@@ -168,6 +168,9 @@ int VL_GetNumBuffers();
 void VL_FixRefreshBuffer();
 void VL_UpdateRect(int x, int y, int w, int h);
 void VL_SwapOnNextPresent();
+void VL_SetScreenSize(int width, int height);
+int VL_ScreenWidth();
+int VL_ScreenHeight();
 void VL_Present();
 
 VL_Backend *VL_Impl_GetBackend(void);

--- a/src/id_vl_dos.c
+++ b/src/id_vl_dos.c
@@ -813,11 +813,14 @@ void VL_DOS_ScrollSurface(void *surface, int x, int y)
 	}
 }
 
-static void VL_DOS_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_DOS_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	VL_DOS_Surface *surf = (VL_DOS_Surface *)surface;
 	uint32_t timeCount = SD_GetTimeCount();
 	bool latchpel = ck_fixJerkyMotion;
+
+	if (width != 320 || height != 200)
+		Quit("Tried to set screen resolution to something other than EGA/VGA\n");
 
 	// Wait for the previous horizontal retrace to end
 	if (vl_swapInterval)

--- a/src/id_vl_null.c
+++ b/src/id_vl_null.c
@@ -245,8 +245,14 @@ static void VL_NULL_ScrollSurface(void *surface, int x, int y)
 	VL_NULL_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
 }
 
-static void VL_NULL_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_NULL_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
+	(void)surface;
+	(void)scrlX;
+	(void)scrlY;
+	(void)width;
+	(void)height;
+	(void)singleBuffered;
 	SD_SetTimeCount(SD_GetTimeCount() + 1);
 }
 

--- a/src/id_vl_private.h
+++ b/src/id_vl_private.h
@@ -100,7 +100,7 @@ extern int vl_integerWidth;
 extern int vl_integerHeight;
 
 // Calculates render regions taking the integer scaling into account.
-void VL_CalculateRenderRegions(int realW, int realH);
+void VL_CalculateRenderRegions(int vgaW, int vgaH, int realW, int realH);
 
 // Calculates a good default window size, given the desktop size.
 int VL_CalculateDefaultWindowScale(int desktopW, int desktopH);

--- a/src/id_vl_sdl12.c
+++ b/src/id_vl_sdl12.c
@@ -1,8 +1,8 @@
-#include "assert.h"
 #include <SDL.h>
 #include <string.h>
 #include "id_vl.h"
 #include "id_vl_private.h"
+#include "id_us.h"
 #include "ck_cross.h"
 
 static SDL_Surface *vl_sdl12_screenSurface;
@@ -321,10 +321,12 @@ static void VL_SDL12_ScrollSurface(void *surface, int x, int y)
 	VL_SDL12_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
 }
 
-static void VL_SDL12_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_SDL12_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	// TODO: Verify this is a VL_SurfaceUsage_FrontBuffer
 	SDL_Surface *surf = (SDL_Surface *)surface;
+	if (vl_sdl12_screenBorderedRect.w != width || vl_sdl12_screenBorderedRect.h != height)
+		Quit("SDL 1.2 backend doesn't support non-default resolutions!");
 	SDL_Rect srcr = {(Sint16)scrlX, (Sint16)scrlY, vl_sdl12_screenBorderedRect.w, vl_sdl12_screenBorderedRect.h};
 	SDL_BlitSurface(surf, &srcr, vl_sdl12_screenSurface, &vl_sdl12_screenBorderedRect);
 	//VL_SDL12_SurfaceToSurface(surface, vl_sdl12_screenSurface, 0, 0, scrlX, scrlY, vl_sdl12_screenWidth, vl_sdl12_screenHeight);

--- a/src/id_vl_sdl2.c
+++ b/src/id_vl_sdl2.c
@@ -11,13 +11,15 @@ static SDL_Texture *vl_sdl2_texture;
 static SDL_Palette *vl_sdl2_palette;
 static SDL_Surface *vl_sdl2_stagingSurface;
 static SDL_Texture *vl_sdl2_scaledTarget;
+static SDL_Surface *vl_sdl2_screenSurface = NULL;
 static bool vl_sdl2_bilinearSupport = true;
 
 static void VL_SDL2_ResizeWindow()
 {
 	int realWinH, realWinW, curW, curH;
 	SDL_GetRendererOutputSize(vl_sdl2_renderer, &realWinW, &realWinH);
-	VL_CalculateRenderRegions(realWinW, realWinH);
+	//TODO: Plumb width through?
+	VL_CalculateRenderRegions(VL_ScreenWidth(), VL_ScreenHeight(), realWinW, realWinH);
 
 	if (vl_sdl2_scaledTarget)
 	{
@@ -82,19 +84,7 @@ static void VL_SDL2_SetVideoMode(int mode)
 		if (!vl_isIntegerScaled && !vl_sdl2_bilinearSupport)
 			CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Using SDL2 software renderer without integer scaling. Pixel size may be inconsistent.\n");
 
-#if !SDL_VERSION_ATLEAST(2, 0, 12)
-		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
-#endif
-		vl_sdl2_texture = SDL_CreateTexture(vl_sdl2_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT);
-#if SDL_VERSION_ATLEAST(2, 0, 12)
-		SDL_SetTextureScaleMode(vl_sdl2_texture, SDL_ScaleModeNearest);
-#endif
-
 		vl_sdl2_palette = SDL_AllocPalette(256);
-
-		// As we can't do on-GPU palette conversions with SDL2,
-		// we do a PAL8->RGBA conversion of the visible area to this surface each frame.
-		vl_sdl2_stagingSurface = SDL_CreateRGBSurface(0, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT, 32, 0, 0, 0, 0);
 
 		VL_SDL2_ResizeWindow();
 		SDL_ShowCursor(0);
@@ -103,7 +93,6 @@ static void VL_SDL2_SetVideoMode(int mode)
 	{
 		SDL_ShowCursor(1);
 		SDL_DestroyTexture(vl_sdl2_scaledTarget);
-		SDL_DestroyTexture(vl_sdl2_texture);
 		SDL_DestroyRenderer(vl_sdl2_renderer);
 		SDL_DestroyWindow(vl_sdl2_window);
 	}
@@ -114,12 +103,34 @@ static void *VL_SDL2_CreateSurface(int w, int h, VL_SurfaceUsage usage)
 {
 	SDL_Surface *s;
 	s = SDL_CreateRGBSurface(0, w, h, 8, 0, 0, 0, 0);
+	if (usage == VL_SurfaceUsage_FrontBuffer)
+	{
+#if !SDL_VERSION_ATLEAST(2, 0, 12)
+		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
+#endif
+		vl_sdl2_texture = SDL_CreateTexture(vl_sdl2_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, w, h);
+#if SDL_VERSION_ATLEAST(2, 0, 12)
+		SDL_SetTextureScaleMode(vl_sdl2_texture, SDL_ScaleModeNearest);
+#endif
+		// As we can't do on-GPU palette conversions with SDL2,
+		// we do a PAL8->RGBA conversion of the visible area to this surface each frame.
+		vl_sdl2_stagingSurface = SDL_CreateRGBSurface(0, w, h, 32, 0, 0, 0, 0);
+
+		vl_sdl2_screenSurface = s;
+	}
 	return s;
 }
 
 static void VL_SDL2_DestroySurface(void *surface)
 {
-	//TODO: Implement
+	SDL_Surface *s = (SDL_Surface *)surface;
+	if (s == vl_sdl2_screenSurface)
+	{
+		SDL_FreeSurface(vl_sdl2_stagingSurface);
+		SDL_DestroyTexture(vl_sdl2_texture);
+		vl_sdl2_screenSurface = NULL;
+	}
+	SDL_FreeSurface(s);
 }
 
 static long VL_SDL2_GetSurfaceMemUse(void *surface)
@@ -332,16 +343,16 @@ static void VL_SDL2_ScrollSurface(void *surface, int x, int y)
 	VL_SDL2_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
 }
 
-static void VL_SDL2_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_SDL2_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	// TODO: Verify this is a VL_SurfaceUsage_FrontBuffer
 	VL_SDL2_ResizeWindow();
 	SDL_Surface *surf = (SDL_Surface *)surface;
-	SDL_Rect srcr = {(Sint16)scrlX, (Sint16)scrlY, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT};
+	SDL_Rect srcr = {(Sint16)scrlX, (Sint16)scrlY, width, height};
 	SDL_Rect renderRect = {(Sint16)vl_renderRgn_x, (Sint16)vl_renderRgn_y, vl_renderRgn_w, vl_renderRgn_h};
 	SDL_Rect fullRect = {(Sint16)vl_fullRgn_x, (Sint16)vl_fullRgn_y, vl_fullRgn_w, vl_fullRgn_h};
 
-	SDL_BlitSurface(surf, &srcr, vl_sdl2_stagingSurface, 0);
+	SDL_BlitSurface(surf, NULL, vl_sdl2_stagingSurface, NULL);
 	SDL_LockSurface(vl_sdl2_stagingSurface);
 	SDL_UpdateTexture(vl_sdl2_texture, 0, vl_sdl2_stagingSurface->pixels, vl_sdl2_stagingSurface->pitch);
 	SDL_UnlockSurface(vl_sdl2_stagingSurface);
@@ -354,7 +365,7 @@ static void VL_SDL2_Present(void *surface, int scrlX, int scrlY, bool singleBuff
 			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2],
 			255);
 		SDL_RenderClear(vl_sdl2_renderer);
-		SDL_RenderCopy(vl_sdl2_renderer, vl_sdl2_texture, 0, &renderRect);
+		SDL_RenderCopy(vl_sdl2_renderer, vl_sdl2_texture, &srcr, &renderRect);
 		SDL_SetRenderTarget(vl_sdl2_renderer, 0);
 		SDL_SetRenderDrawColor(vl_sdl2_renderer, 0, 0, 0, 255);
 		SDL_RenderClear(vl_sdl2_renderer);
@@ -377,7 +388,7 @@ static void VL_SDL2_Present(void *surface, int scrlX, int scrlY, bool singleBuff
 			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2],
 			255);
 		SDL_RenderFillRect(vl_sdl2_renderer, 0);
-		SDL_RenderCopy(vl_sdl2_renderer, vl_sdl2_texture, 0, &renderRect);
+		SDL_RenderCopy(vl_sdl2_renderer, vl_sdl2_texture, &srcr, &renderRect);
 
 	}
 

--- a/src/id_vl_sdl2gl.c
+++ b/src/id_vl_sdl2gl.c
@@ -558,13 +558,13 @@ static void VL_SDL2GL_ScrollSurface(void *surface, int x, int y)
 		VL_SDL2GL_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
 }
 
-static void VL_SDL2GL_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_SDL2GL_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	int realWinW, realWinH;
 	// Get the real window size
 	SDL_GL_GetDrawableSize(vl_sdl2gl_window, &realWinW, &realWinH);
 
-	VL_CalculateRenderRegions(realWinW, realWinH);
+	VL_CalculateRenderRegions(width, height, realWinW, realWinH);
 
 	if (vl_isAspectCorrected || vl_isIntegerScaled)
 	{
@@ -623,8 +623,8 @@ static void VL_SDL2GL_Present(void *surface, int scrlX, int scrlY, bool singleBu
 	id_glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	id_glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, surf->w, surf->h, GL_RED, GL_UNSIGNED_BYTE, surf->data);
 
-	float scaleX = (float)vl_sdl2gl_screenWidth / ((float)surf->w);
-	float scaleY = (float)vl_sdl2gl_screenHeight / ((float)surf->h);
+	float scaleX = (float)width / ((float)surf->w);
+	float scaleY = (float)height / ((float)surf->h);
 	float offX = (float)(scrlX) / (float)(surf->w);
 	float offY = (float)(scrlY) / (float)(surf->h);
 	float endX = offX + scaleX;

--- a/src/id_vl_sdl2vk.c
+++ b/src/id_vl_sdl2vk.c
@@ -449,7 +449,7 @@ static void VL_SDL2VK_SetupSwapchain(int width, int height)
 	// trying to blit to a fullRgn that exceeds the surface size.
 	// See, for example: https://bugzilla.libsdl.org/show_bug.cgi?id=4671
 	// By using the actual swapchain size here, it should always be correct
-	VL_CalculateRenderRegions(vl_sdl2vk_swapchainSize.width, vl_sdl2vk_swapchainSize.height);
+	VL_CalculateRenderRegions(VL_ScreenWidth(), VL_ScreenHeight(), vl_sdl2vk_swapchainSize.width, vl_sdl2vk_swapchainSize.height);
 
 	int desiredFormat = 0;
 	for (int i = 0; i < surfaceFormatCount; ++i)
@@ -1183,7 +1183,7 @@ static void VL_SDL2VK_SetVideoMode(int mode)
 		vl_sdl2vk_screenWidth = VL_EGAVGA_GFX_WIDTH;
 		vl_sdl2vk_screenHeight = VL_EGAVGA_GFX_HEIGHT;
 
-		VL_CalculateRenderRegions(VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale));
+		VL_CalculateRenderRegions(vl_sdl2vk_screenWidth, vl_sdl2vk_screenHeight, VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale));
 
 		SDL_SetWindowMinimumSize(vl_sdl2vk_window, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER / VL_VGA_GFX_WIDTH_SCALEFACTOR, VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER / VL_VGA_GFX_HEIGHT_SCALEFACTOR);
 
@@ -1668,20 +1668,27 @@ static void VL_SDL2VK_ScrollSurface(void *surface, int x, int y)
 	VL_SDL2VK_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
 }
 
-static void VL_SDL2VK_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_SDL2VK_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	VkResult result = VK_SUCCESS;
 	uint32_t framebufferIndex;
 
 	int newW, newH;
 	SDL_Vulkan_GetDrawableSize(vl_sdl2vk_window, &newW, &newH);
-	if (vl_sdl2vk_flushSwapchain || vl_sdl2vk_swapchainSize.width != newW || vl_sdl2vk_swapchainSize.height != newH)
+	if (vl_sdl2vk_swapchainSize.width != newW || vl_sdl2vk_swapchainSize.height != newH)
+		vl_sdl2vk_flushSwapchain = true;
+	if (vl_sdl2vk_screenWidth != width || vl_sdl2vk_screenHeight != height)
+		vl_sdl2vk_flushSwapchain = true;
+	if (vl_sdl2vk_flushSwapchain)
 	{
+		CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "VL_SDL2VK_Present: Recreating swapchain (%d×%d), (%d×%d)\n", newW, newH, width, height);
 		VL_SDL2VK_DestroySwapchain();
 		VL_SDL2VK_SetupSwapchain(newW, newH);
 		VL_SDL2VK_CreateFramebuffers(vl_integerWidth, vl_integerHeight);
 		VL_SDL2VK_CreatePipeline();
 		vl_sdl2vk_flushSwapchain = false;
+		vl_sdl2vk_screenWidth = width;
+		vl_sdl2vk_screenHeight = height;
 	}
 
 	result = vkAcquireNextImageKHR(vl_sdl2vk_device, vl_sdl2vk_swapchain, UINT64_MAX, vl_sdl2vk_imageAvailableSemaphore, VK_NULL_HANDLE, &framebufferIndex);
@@ -1724,8 +1731,8 @@ static void VL_SDL2VK_Present(void *surface, int scrlX, int scrlY, bool singleBu
 	vkMapMemory(vl_sdl2vk_device, vl_sdl2vk_uniformBufferMemory, 0, sizeof(float) * 4 * 17, 0, (void **)&data);
 	data[0] = scrlX;
 	data[1] = scrlY;
-	data[2] = VL_EGAVGA_GFX_WIDTH;
-	data[3] = VL_EGAVGA_GFX_HEIGHT;
+	data[2] = width;
+	data[3] = height;
 	for (int i = 0; i < 16; ++i)
 	{
 		data[4 + 4 * i] = (float)VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][0] / 255.0;

--- a/src/id_vl_sdl3.c
+++ b/src/id_vl_sdl3.c
@@ -11,6 +11,7 @@ static SDL_Renderer *vl_sdl3_renderer;
 static SDL_Texture *vl_sdl3_texture;
 static SDL_Palette *vl_sdl3_palette;
 static SDL_Surface *vl_sdl3_stagingSurface;
+static SDL_Surface *vl_sdl3_screenSurface = NULL;
 static SDL_Texture *vl_sdl3_scaledTarget;
 static bool vl_sdl3_bilinearSupport = true;
 // Should we resolve the palette on the CPU (as is required pre-SDL-3.4.0)
@@ -24,7 +25,7 @@ static void VL_SDL3_ResizeWindow()
 {
 	int realWinH, realWinW, curW, curH;
 	SDL_GetCurrentRenderOutputSize(vl_sdl3_renderer, &realWinW, &realWinH);
-	VL_CalculateRenderRegions(realWinW, realWinH);
+	VL_CalculateRenderRegions(VL_ScreenWidth(), VL_ScreenHeight(), realWinW, realWinH);
 
 	if (vl_sdl3_scaledTarget)
 	{
@@ -90,26 +91,7 @@ static void VL_SDL3_SetVideoMode(int mode)
 		if (!vl_isIntegerScaled && !vl_sdl3_bilinearSupport)
 			CK_Cross_LogMessage(CK_LOG_MSG_WARNING, "Using SDL3 software renderer without integer scaling. Pixel size may be inconsistent.\n");
 
-		if (vl_sdl3_swPalette)
-		{
-			vl_sdl3_texture = SDL_CreateTexture(vl_sdl3_renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT);
-			SDL_SetTextureScaleMode(vl_sdl3_texture, SDL_SCALEMODE_NEAREST);
-			// As we can't do on-GPU palette conversions with SDL3,
-			// we do a PAL8->RGBA conversion of the visible area to this surface each frame.
-			vl_sdl3_stagingSurface = SDL_CreateSurface(VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT, SDL_PIXELFORMAT_RGBA8888);
-		}
-		else
-		{
-#if SDL_VERSION_ATLEAST(3,4,0)
-			vl_sdl3_texture = SDL_CreateTexture(vl_sdl3_renderer, SDL_PIXELFORMAT_INDEX8, SDL_TEXTUREACCESS_STREAMING, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT);
-			SDL_SetTextureScaleMode(vl_sdl3_texture, SDL_SCALEMODE_NEAREST);
-#else
-			Quit("This build requires SDL 3.4.0 or newer!");
-#endif
-		}
-
 		vl_sdl3_palette = SDL_CreatePalette(256);
-
 
 		VL_SDL3_ResizeWindow();
 		SDL_HideCursor();
@@ -117,8 +99,8 @@ static void VL_SDL3_SetVideoMode(int mode)
 	else
 	{
 		SDL_ShowCursor();
-		SDL_DestroyTexture(vl_sdl3_scaledTarget);
-		SDL_DestroyTexture(vl_sdl3_texture);
+		if (vl_sdl3_scaledTarget)
+			SDL_DestroyTexture(vl_sdl3_scaledTarget);
 		SDL_DestroyRenderer(vl_sdl3_renderer);
 		SDL_DestroyWindow(vl_sdl3_window);
 	}
@@ -129,12 +111,40 @@ static void *VL_SDL3_CreateSurface(int w, int h, VL_SurfaceUsage usage)
 {
 	SDL_Surface *s;
 	s = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_INDEX8);
+	if (usage == VL_SurfaceUsage_FrontBuffer)
+	{
+		if (vl_sdl3_swPalette)
+		{
+			vl_sdl3_texture = SDL_CreateTexture(vl_sdl3_renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, w, h);
+			SDL_SetTextureScaleMode(vl_sdl3_texture, SDL_SCALEMODE_NEAREST);
+			// As we can't do on-GPU palette conversions with SDL3,
+			// we do a PAL8->RGBA conversion of the visible area to this surface each frame.
+			vl_sdl3_stagingSurface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_RGBA8888);
+		}
+		else
+		{
+			#if SDL_VERSION_ATLEAST(3,4,0)
+			vl_sdl3_texture = SDL_CreateTexture(vl_sdl3_renderer, SDL_PIXELFORMAT_INDEX8, SDL_TEXTUREACCESS_STREAMING, w, h);
+			SDL_SetTextureScaleMode(vl_sdl3_texture, SDL_SCALEMODE_NEAREST);
+			#else
+			Quit("This build requires SDL 3.4.0 or newer!");
+			#endif
+		}
+		vl_sdl3_screenSurface = s;
+	}
 	return s;
 }
 
 static void VL_SDL3_DestroySurface(void *surface)
 {
 	SDL_Surface *surf = (SDL_Surface *)surface;
+	if (surf == vl_sdl3_screenSurface)
+	{
+		if (vl_sdl3_swPalette)
+			SDL_DestroySurface(vl_sdl3_stagingSurface);
+		SDL_DestroyTexture(vl_sdl3_texture);
+		vl_sdl3_screenSurface = NULL;
+	}
 	SDL_DestroySurface(surf);
 }
 
@@ -341,19 +351,19 @@ static void VL_SDL3_ScrollSurface(void *surface, int x, int y)
 	VL_SDL3_SurfaceToSelf(surface, dx, dy, sx, sy, w, h);
 }
 
-static void VL_SDL3_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_SDL3_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	// TODO: Verify this is a VL_SurfaceUsage_FrontBuffer
 	VL_SDL3_ResizeWindow();
 	SDL_Surface *surf = (SDL_Surface *)surface;
-	SDL_Rect srcr = {(Sint16)scrlX, (Sint16)scrlY, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT};
+	SDL_FRect srcr = {(float)scrlX, (float)scrlY, (float)width, (float)height};
 	SDL_FRect renderRect = {(float)vl_renderRgn_x, (float)vl_renderRgn_y, (float)vl_renderRgn_w, (float)vl_renderRgn_h};
 	SDL_Rect fullRect = {(Sint16)vl_fullRgn_x, (Sint16)vl_fullRgn_y, vl_fullRgn_w, vl_fullRgn_h};
 	SDL_FRect fullRectF = {(float)vl_fullRgn_x, (float)vl_fullRgn_y, (float)vl_fullRgn_w, (float)vl_fullRgn_h};
 
 	if (vl_sdl3_swPalette)
 	{
-		SDL_BlitSurface(surf, &srcr, vl_sdl3_stagingSurface, 0);
+		SDL_BlitSurface(surf, NULL, vl_sdl3_stagingSurface, NULL);
 		SDL_LockSurface(vl_sdl3_stagingSurface);
 		SDL_UpdateTexture(vl_sdl3_texture, 0, vl_sdl3_stagingSurface->pixels, vl_sdl3_stagingSurface->pitch);
 		SDL_UnlockSurface(vl_sdl3_stagingSurface);
@@ -362,7 +372,7 @@ static void VL_SDL3_Present(void *surface, int scrlX, int scrlY, bool singleBuff
 	else
 	{
 		SDL_LockSurface(surf);
-		SDL_UpdateTexture(vl_sdl3_texture, 0, (uint8_t *)surf->pixels + (scrlY * surf->pitch) + scrlX, surf->pitch);
+		SDL_UpdateTexture(vl_sdl3_texture, 0, surf->pixels, surf->pitch);
 		SDL_UnlockSurface(surf);
 		SDL_SetTexturePalette(vl_sdl3_texture, vl_sdl3_palette);
 	}
@@ -376,7 +386,7 @@ static void VL_SDL3_Present(void *surface, int scrlX, int scrlY, bool singleBuff
 			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2],
 			255);
 		SDL_RenderClear(vl_sdl3_renderer);
-		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_texture, 0, &renderRect);
+		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_texture, &srcr, &renderRect);
 		SDL_SetRenderTarget(vl_sdl3_renderer, 0);
 		SDL_SetRenderDrawColor(vl_sdl3_renderer, 0, 0, 0, 255);
 		SDL_RenderClear(vl_sdl3_renderer);
@@ -399,7 +409,7 @@ static void VL_SDL3_Present(void *surface, int scrlX, int scrlY, bool singleBuff
 			VL_EGARGBColorTable[vl_emuegavgaadapter.bordercolor][2],
 			255);
 		SDL_RenderFillRect(vl_sdl3_renderer, 0);
-		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_texture, 0, &renderRect);
+		SDL_RenderTexture(vl_sdl3_renderer, vl_sdl3_texture, &srcr, &renderRect);
 
 	}
 

--- a/src/id_vl_sdl3gpu.c
+++ b/src/id_vl_sdl3gpu.c
@@ -59,9 +59,6 @@ static SDL_GPUGraphicsPipeline *vl_sdl3gpu_pipeline;
 
 static SDL_GPUSampler *vl_sdl3gpu_sampler;
 
-static int vl_sdl3gpu_integerWidth;
-static int vl_sdl3gpu_integerHeight;
-
 static SDL_GPUTexture *vl_sdl3gpu_integerFramebuffer;
 
 static SDL_GPUPresentMode vl_sdl3gpu_supportedNoVsyncMode;
@@ -214,7 +211,7 @@ static void VL_SDL3GPU_SetVideoMode(int mode)
 		VL_SDL3GPU_CreateShaders();
 		VL_SDL3GPU_CreatePipeline();
 
-		VL_CalculateRenderRegions(VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale));
+		VL_CalculateRenderRegions(VL_ScreenWidth(), VL_ScreenHeight(), VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale));
 		VL_SDL3GPU_CreateFramebuffers();
 
 
@@ -541,12 +538,12 @@ static void VL_SDL3GPU_BindTexture(VL_SDL3GPU_Surface *surf, SDL_GPURenderPass *
 	//SDL_BindGPUFragmentSamplers(renderPass, 0, &binding, 1);
 }
 
-static void VL_SDL3GPU_Present(void *surface, int scrlX, int scrlY, bool singleBuffered)
+static void VL_SDL3GPU_Present(void *surface, int scrlX, int scrlY, int width, int height, bool singleBuffered)
 {
 	SDL_GPUTexture *swapchainTexture;
 	VL_SDL3GPU_Surface *surf = (VL_SDL3GPU_Surface *)surface;
 
-	uint32_t newW, newH;
+	uint32_t newW, newH, oldIntWidth, oldIntHeight;
 	VL_SDL3GPU_UploadSurface(surface);
 	SDL_GPUCommandBuffer *renderBuffer = SDL_AcquireGPUCommandBuffer(vl_sdl3gpu_device);
 	if (!SDL_AcquireGPUSwapchainTexture(renderBuffer, vl_sdl3_window, &swapchainTexture, &newW, &newH) || !swapchainTexture)
@@ -560,7 +557,12 @@ static void VL_SDL3GPU_Present(void *surface, int scrlX, int scrlY, bool singleB
 		CK_Cross_LogMessage(CK_LOG_MSG_NORMAL, "Resizing swapchain: %d -> %d, %d -> %d\n", vl_sdl3gpu_screenWidth, vl_sdl3gpu_screenHeight, newW, newH);
 		vl_sdl3gpu_screenWidth = newW;
 		vl_sdl3gpu_screenHeight = newH;
-		VL_CalculateRenderRegions(newW, newH);
+	}
+	oldIntWidth = vl_integerWidth;
+	oldIntHeight = vl_integerHeight;
+	VL_CalculateRenderRegions(width, height, newW, newH);
+	if (vl_integerWidth != oldIntWidth || vl_integerHeight != oldIntHeight)
+	{
 		SDL_ReleaseGPUTexture(vl_sdl3gpu_device, vl_sdl3gpu_integerFramebuffer);
 		VL_SDL3GPU_CreateFramebuffers();
 		vl_sdl3gpu_flushSwapchain = false;
@@ -595,8 +597,8 @@ static void VL_SDL3GPU_Present(void *surface, int scrlX, int scrlY, bool singleB
 	float data[4 * 17];
 	data[0] = scrlX;
 	data[1] = scrlY;
-	data[2] = VL_EGAVGA_GFX_WIDTH;
-	data[3] = VL_EGAVGA_GFX_HEIGHT;
+	data[2] = width;
+	data[3] = height;
 	for (int i = 0; i < 16; ++i)
 	{
 		data[4 + 4 * i] = (float)VL_EGARGBColorTable[vl_emuegavgaadapter.palette[i]][0] / 255.0;


### PR DESCRIPTION
At last! An attempt to get widescreen support into Omnispeak!

**This is _very_ buggy at the moment, and will _always_ have some bugs, as several parts of the game (including levels) were designed specifically around 320×200.**

Commander Keen was always designed around the 320×200 resolution and this is hardcoded in several places throughout the code (and, as mentioned above, things like the level design). This PR makes a first attempt at supporting increased resolutions in the graphics code and backends (ID_VL), the Refresh Manager (ID_RF), and the gameplay code. Some of this works okay, but there's probably some tweaking needed in (for example) the camera movement to make it ideal.

To try it out set 'screenWidth' in `OMNISPK.CFG` to a value other than 320. Because pixels are still non-square, you'll want to calculate the resolution for a given aspect ratio as though the height is 240. For example:
- For 16:9, use ``screenWidth = 427`` (technically, 426.67, but what can you do?)
- For 16:10, use ``screenWidth = 384``
- For 3:2, use ``screenWidth = 360``
- For 21:9, use ``screenWidth = 560``
- For 2.39:1, use ``screenWidth = 574``

(You can also increase ``screenHeight`` if you want, but you'll likely hit brokenness even more quickly.)

Note that, the wider the resolution, the more broken this will be. This is mostly due to levels, which are sized (and place scroll blockers) with the assumption of 320×200. So expect to see some things you shouldn't. It's also likely, particularly at higher resolutions, that you'll start to run into crashes due to exceeding the limits on number of onscreen sprites/objects/animated tiles/etc. These are still hardcoded, and the more is visible onscreen, the more likely you'll hit them.

Also note that this will break things like DEMO playback/recording. As a result, these (and the menus) will revert to the hardcoded 320×200 resolution (though you can modify rf_demoScreenWidth/rf_demoScreenHeight in EPISODE.CKx for mods). Also, this is not supported in the DOS/EGA version, nor in the SDL 1.2 version. They'll crash if screenWidth/screenHeight is not exactly 320×200. And, as a really subtle breakage: the way the clipping bugs at the top of Lifewater Oasis in Keen 4 are emulated is incompatible with some higher resolutions, so it's disabled by default in this case. You can re-enable it with ``ca_emulateMapGarbage = true``, but it'll make things like the BwB Megarocket levels crash, so be warned.

I'll slowly polish this up a bit, and if I can find a way to work around the worst of the glitches, may add it to the options menu somewhere. In the meantime, feel free to play around with it.