### PR TITLE
Add cross-build for Miyoo Mini/Mini+

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ NY00123
 lemm
 BSzili
 KeyJ
+tgies
 
 Includes the DOSBox OPL2/3 Emulator:
 	Copyright (C) 2002-2010  The DOSBox Team

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,7 @@ This Makefile supports the following options:
                   win64   = MinGW cross-build for 64-bit Windows
                   dos     = DJGPP cross-build for DOS (with DOS Extender)
                   gcw0    = OpenDingux cross-build for GCW Zero
+                  miyoo   = cross-build for Miyoo Mini Plus (OnionOS)
 
   RENDERER      the type of video output API (not available for PLATFORM=dos)
 		  sdl1    = SDL 1.2 (deprecated; no win64 support)
@@ -157,6 +158,16 @@ ifeq ($(PLATFORM), gcw0)
         DEFAULT_BUILDASCPP = 1
         # HACK: gcw0 misel architecture doesn't define O_PATH
         CXXFLAGS += -DO_PATH=010000000
+endif
+
+ifeq ($(PLATFORM), miyoo)
+        OUTDIR_SUFFIX := -miyoo
+        MIYOO_TOOLCHAIN_DIR = /opt/miyoomini-toolchain
+        TOOLSET = arm-linux-gnueabihf
+        TOOLDIR = $(MIYOO_TOOLCHAIN_DIR)/usr/bin
+        DEFAULT_RENDERER = sdl2sw
+        SDL_CONFIG_PREFIX = $(MIYOO_SDL2_PREFIX)/bin/
+        DEFAULT_BUILDASCPP = 1
 endif
 
 ifeq ($(OUTDIR_SUFFIX),INVALID)
@@ -339,6 +350,20 @@ ifeq ($(PLATFORM), gcw0)
 		SHELLFILES += $(BINDIR)/keen6.sh
 	endif
         SHELLOPTS = /FULLSCREEN /NOBORDER /NOCOPY
+endif
+
+# set Miyoo Mini Plus-specific parameters
+ifeq ($(PLATFORM), miyoo)
+	ifeq ($(WITH_KEEN4),1)
+		SHELLFILES += $(BINDIR)/keen4.sh
+	endif
+	ifeq ($(WITH_KEEN5),1)
+		SHELLFILES += $(BINDIR)/keen5.sh
+	endif
+	ifeq ($(WITH_KEEN6),1)
+		SHELLFILES += $(BINDIR)/keen6.sh
+	endif
+        SHELLOPTS = /FULLSCREEN /NOBORDER /INTEGER /NOCOPY
 endif
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/id_vl_sdl2.c
+++ b/src/id_vl_sdl2.c
@@ -5,6 +5,12 @@
 #include "id_vl_private.h"
 #include "ck_cross.h"
 
+#ifdef VL_MIYOO
+#define VL_SDL2_PIXEL_FORMAT SDL_PIXELFORMAT_RGB565
+#else
+#define VL_SDL2_PIXEL_FORMAT SDL_PIXELFORMAT_ARGB8888
+#endif
+
 static SDL_Window *vl_sdl2_window;
 static SDL_Renderer *vl_sdl2_renderer;
 static SDL_Texture *vl_sdl2_texture;
@@ -38,7 +44,7 @@ static void VL_SDL2_ResizeWindow()
 #if !SDL_VERSION_ATLEAST(2, 0, 12)
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 #endif
-		vl_sdl2_scaledTarget = SDL_CreateTexture(vl_sdl2_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, vl_integerWidth, vl_integerHeight);
+		vl_sdl2_scaledTarget = SDL_CreateTexture(vl_sdl2_renderer, VL_SDL2_PIXEL_FORMAT, SDL_TEXTUREACCESS_TARGET, vl_integerWidth, vl_integerHeight);
 #if SDL_VERSION_ATLEAST(2, 0, 12)
 		SDL_SetTextureScaleMode(vl_sdl2_scaledTarget, SDL_ScaleModeLinear);
 #endif
@@ -59,7 +65,13 @@ static void VL_SDL2_SetVideoMode(int mode)
 		int scale = VL_CalculateDefaultWindowScale(desktopBounds.w, desktopBounds.h);
 		vl_sdl2_window = SDL_CreateWindow(VL_WINDOW_TITLE, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
 			VL_DEFAULT_WINDOW_WIDTH(scale), VL_DEFAULT_WINDOW_HEIGHT(scale),
-			SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE | (vl_isFullScreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0));
+			SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE
+#ifdef VL_MIYOO
+			| SDL_WINDOW_SHOWN
+#else
+			| (vl_isFullScreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0)
+#endif
+			);
 
 		SDL_SetWindowMinimumSize(vl_sdl2_window, VL_VGA_GFX_SCALED_WIDTH_PLUS_BORDER / VL_VGA_GFX_WIDTH_SCALEFACTOR, VL_VGA_GFX_SCALED_HEIGHT_PLUS_BORDER / VL_VGA_GFX_HEIGHT_SCALEFACTOR);
 
@@ -85,7 +97,7 @@ static void VL_SDL2_SetVideoMode(int mode)
 #if !SDL_VERSION_ATLEAST(2, 0, 12)
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
 #endif
-		vl_sdl2_texture = SDL_CreateTexture(vl_sdl2_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT);
+		vl_sdl2_texture = SDL_CreateTexture(vl_sdl2_renderer, VL_SDL2_PIXEL_FORMAT, SDL_TEXTUREACCESS_STREAMING, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT);
 #if SDL_VERSION_ATLEAST(2, 0, 12)
 		SDL_SetTextureScaleMode(vl_sdl2_texture, SDL_ScaleModeNearest);
 #endif
@@ -94,7 +106,10 @@ static void VL_SDL2_SetVideoMode(int mode)
 
 		// As we can't do on-GPU palette conversions with SDL2,
 		// we do a PAL8->RGBA conversion of the visible area to this surface each frame.
-		vl_sdl2_stagingSurface = SDL_CreateRGBSurface(0, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT, 32, 0, 0, 0, 0);
+		int surfaceBpp;
+		Uint32 surfaceRMask, surfaceGMask, surfaceBMask, surfaceAMask;
+		SDL_PixelFormatEnumToMasks(VL_SDL2_PIXEL_FORMAT, &surfaceBpp, &surfaceRMask, &surfaceGMask, &surfaceBMask, &surfaceAMask);
+		vl_sdl2_stagingSurface = SDL_CreateRGBSurface(0, VL_EGAVGA_GFX_WIDTH, VL_EGAVGA_GFX_HEIGHT, surfaceBpp, surfaceRMask, surfaceGMask, surfaceBMask, surfaceAMask);
 
 		VL_SDL2_ResizeWindow();
 		SDL_ShowCursor(0);


### PR DESCRIPTION
Add a cross-build for the Miyoo Mini Plus handheld (tested on the OnionUI firmware, which is what everyone uses, but I think it should work regardless). This is one of the most popular of the little cheapo Game Boy-shaped handhelds.

Of note is the change that was necessary to use RGB565 pixel format for this target because the Miyoo has this [incredibly odd video driver](https://wx.comake.online/doc/d8clf27cnes2-SSD20X/customer/development/mi/en/mi_gfx.html) that doesn't seem to like anything else, but I'm not totally certain I'm not doing something wrong, nor am I certain this is the cleanest way to handle this. Draft status for now until I hammer that out. (also I just realized there is some weird crap in here from when I was debugging a joystick-related issue -- will clean that up)