### PR TITLE
id_in: Guard joystick input on joystick presence

### DIFF
--- a/src/id_in.c
+++ b/src/id_in.c
@@ -581,11 +581,19 @@ bool IN_JoyPresent(int joystick)
 
 void IN_GetJoyAbs(int joystick, int *x, int *y)
 {
+	if (!in_backend->joyPresent(joystick))
+	{
+		if (x) *x = 0;
+		if (y) *y = 0;
+		return;
+	}
 	in_backend->joyGetAbs(joystick, x, y);
 }
 
 uint16_t IN_GetJoyButtonsDB(int joystick)
 {
+	if (!in_backend->joyPresent(joystick))
+		return 0;
 	return in_backend->joyGetButtons(joystick);
 }
 


### PR DESCRIPTION
IN_GetJoyAbs() and IN_GetJoyButtonsDB() forwarded straight to the backend, which looks at a closed joystick handle when the joystick is absent. IN_JoyButtonDown() and IN_GetJoyMotion() hit this path. Gate both wrappers on in_backend->joyPresent().